### PR TITLE
bugfix(TESB-32508): upgrade swagger version to 1.6.2, due to jackson …

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -309,10 +309,10 @@
         <bundle start-level="30" dependency="true">mvn:org.javassist/javassist/${cxf.javassist.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${cxf.reflections.bundle.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.swagger2.guava.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-annotations/${cxf.swagger2.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-models/${cxf.swagger2.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-core/${cxf.swagger2.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-jaxrs/${cxf.swagger2.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-annotations/${cxf.swagger2.tesb.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-models/${cxf.swagger2.tesb.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-core/${cxf.swagger2.tesb.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-jaxrs/${cxf.swagger2.tesb.version}</bundle>
     </feature>
     <feature name="cxf-rs-description-openapi-v3" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-jaxrs</feature>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2402,7 +2402,7 @@
             <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-jaxrs</artifactId>
-                <version>${cxf.swagger2.version}</version>
+                <version>${cxf.swagger2.tesb.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <cxf.joda.time.tesb.version>2.10.1</cxf.joda.time.tesb.version>
         <cxf.javax.mail.tesb.version>1.6.1</cxf.javax.mail.tesb.version>
         <cxf.snakeyaml.tesb.version>1.26</cxf.snakeyaml.tesb.version>
+        <cxf.swagger2.tesb.version>1.6.2</cxf.swagger2.tesb.version>
 
         <cxf.compiler.fork>false</cxf.compiler.fork>
         <cxf.build-utils.version>3.4.3</cxf.build-utils.version>
@@ -456,6 +457,7 @@
                             <cxf.joda.time.tesb.version>${cxf.joda.time.tesb.version}</cxf.joda.time.tesb.version>
                             <cxf.javax.mail.tesb.version>${cxf.javax.mail.tesb.version}</cxf.javax.mail.tesb.version>
                             <cxf.snakeyaml.tesb.version>${cxf.snakeyaml.tesb.version}</cxf.snakeyaml.tesb.version>
+                            <cxf.swagger2.tesb.version>${cxf.swagger2.tesb.version}</cxf.swagger2.tesb.version>
                         </properties>
                     </configuration>
                     <executions>


### PR DESCRIPTION
…version upgrade to 2.11.4

No repo feature version upgrade as part of the same patch