### PR TITLE
bugfix(TESB-32508): upgrade swagger version to 1.6.2, due to jackson …

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -305,10 +305,10 @@
         <bundle start-level="30" dependency="true">mvn:org.javassist/javassist/${cxf.javassist.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${cxf.reflections.bundle.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.swagger2.guava.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-annotations/${cxf.swagger2.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-models/${cxf.swagger2.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-core/${cxf.swagger2.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-jaxrs/${cxf.swagger2.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-annotations/${cxf.swagger2.tesb.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-models/${cxf.swagger2.tesb.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-core/${cxf.swagger2.tesb.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-jaxrs/${cxf.swagger2.tesb.version}</bundle>
     </feature>
     <feature name="cxf-rs-description-openapi-v3" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-jaxrs</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <cxf.dom4j.bundle.tesb.version>2.1.3_1</cxf.dom4j.bundle.tesb.version>
         <cxf.jackson.tesb.version>2.11.4</cxf.jackson.tesb.version>
         <cxf.jackson.databind.tesb.version>${cxf.jackson.tesb.version}</cxf.jackson.databind.tesb.version>
+        <cxf.swagger2.tesb.version>1.6.2</cxf.swagger2.tesb.version>
 
         <cxf.compiler.fork>false</cxf.compiler.fork>
         <cxf.build-utils.version>3.4.4</cxf.build-utils.version>
@@ -446,7 +447,7 @@
                             <cxf.dom4j.bundle.tesb.version>${cxf.dom4j.bundle.tesb.version}</cxf.dom4j.bundle.tesb.version>
                             <cxf.jackson.tesb.version>${cxf.jackson.tesb.version}</cxf.jackson.tesb.version>
                             <cxf.jackson.databind.tesb.version>${cxf.jackson.databind.tesb.version}</cxf.jackson.databind.tesb.version>
-
+                            <cxf.swagger2.tesb.version>${cxf.swagger2.tesb.version}</cxf.swagger2.tesb.version>
                         </properties>
                     </configuration>
                     <executions>


### PR DESCRIPTION
…version upgrade to 2.11.4

No repo feature version upgrade as part of the same master