### PR TITLE
fix(TPRUN-4595) : Change xml validation strategy

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: ':cxf-rt-ws-security,:cxf-services-wsn-core,:apache-cxf,:cxf-rt-features-logging,:cxf-services-xkms-features'
+        MVN_MODULES: ':cxf-rt-ws-security,:cxf-services-wsn-core,:apache-cxf,:cxf-rt-features-logging,:cxf-services-xkms-features,:cxf-core'
 )

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,7 @@
     <name>Apache CXF Core</name>
     <description>Apache CXF Core</description>
     <url>https://cxf.apache.org</url>
+    <version>${revision}</version>
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
@@ -31,6 +32,7 @@
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <revision>${cxf-core.tesb.version}</revision>
         <cxf.module.name>org.apache.cxf.core</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.bus.osgi.CXFActivator</cxf.bundle.activator>
         <cxf.osgi.export>

--- a/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
+++ b/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
@@ -29,7 +29,6 @@ import javax.activation.DataSource;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
@@ -118,7 +117,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             if (type != null) {
                 Object retVal = null;
                 if (SAXSource.class.isAssignableFrom(type)
-                    || StaxSource.class.isAssignableFrom(type)) {
+                        || StaxSource.class.isAssignableFrom(type)) {
                     retVal = new StaxSource(resetForStreaming(input));
                 } else if (StreamSource.class.isAssignableFrom(type)) {
                     retVal = new StreamSource(getInputStream(input));
@@ -160,7 +159,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             throw new Fault("COULD_NOT_READ_XML_STREAM", LOG, e);
         } catch (XMLStreamException e) {
             throw new Fault("COULD_NOT_READ_XML_STREAM_CAUSED_BY", LOG, e,
-                            e.getClass().getCanonicalName(), e.getMessage());
+                    e.getClass().getCanonicalName(), e.getMessage());
         }
     }
 
@@ -216,41 +215,43 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     }
 
     private Element validate(XMLStreamReader input) throws XMLStreamException, IOException {
-        DOMSource ds = read(input);
-        final Element rootElement;
-        if (ds.getNode() instanceof Document) {
-            rootElement = ((Document)ds.getNode()).getDocumentElement();
-        } else {
-            rootElement = (Element)ds.getNode();
-        }
-
+        Element rootElement;
         WoodstoxValidationImpl impl = new WoodstoxValidationImpl();
-        XMLStreamWriter nullWriter = null;
         if (impl.canValidate()) {
-            nullWriter = StaxUtils.createXMLStreamWriter(new NUllOutputStream());
-            impl.setupValidation(nullWriter, message.getExchange().getEndpoint(),
-                                 message.getExchange().getService().getServiceInfos().get(0));
+
+            impl.setupValidation(input, message.getExchange().getEndpoint(),
+                    message.getExchange().getService().getServiceInfos().get(0));
         }
         //check if the impl can still validate after the setup, possible issue loading schemas or similar
         if (impl.canValidate()) {
             //Can use the MSV libs and woodstox to handle the schema validation during
             //parsing and processing.   Much faster and single traversal
             //filter xop node
-            XMLStreamReader reader = StaxUtils.createXMLStreamReader(ds);
-            XMLStreamReader filteredReader =
-                StaxUtils.createFilteredReader(reader,
-                                               new StaxStreamFilter(new QName[] {XOP}));
 
-            StaxUtils.copy(filteredReader, nullWriter);
+            XMLStreamReader filteredReader =
+                    StaxUtils.createFilteredReader(input,
+                            new StaxStreamFilter(new QName[] {XOP}));
+
+            rootElement =  StaxUtils.read(filteredReader).getDocumentElement();
+
         } else {
+
+            DOMSource ds = read(input);
+            if (ds.getNode() instanceof Document) {
+                rootElement = ((Document)ds.getNode()).getDocumentElement();
+            } else {
+                rootElement = (Element)ds.getNode();
+            }
+
+
             //MSV not available, use a slower method of cloning the data, replace the xop's, validate
             LOG.fine("NO_MSV_AVAILABLE");
             Element newElement = rootElement;
             if (DOMUtils.hasElementWithName(rootElement, "http://www.w3.org/2004/08/xop/include", "Include")) {
                 newElement = (Element)rootElement.cloneNode(true);
                 List<Element> elems = DOMUtils.findAllElementsByTagNameNS(newElement,
-                                                                          "http://www.w3.org/2004/08/xop/include",
-                                                                          "Include");
+                        "http://www.w3.org/2004/08/xop/include",
+                        "Include");
                 for (Element include : elems) {
                     Node parentNode = include.getParentNode();
                     parentNode.removeChild(include);
@@ -269,7 +270,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     }
 
     private InputStream getInputStream(XMLStreamReader input)
-        throws XMLStreamException, IOException {
+            throws XMLStreamException, IOException {
 
         try (CachedOutputStream out = new CachedOutputStream()) {
             StaxUtils.copy(input, out);
@@ -298,7 +299,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             return new DOMSource(document);
         } catch (XMLStreamException e) {
             throw new Fault("COULD_NOT_READ_XML_STREAM_CAUSED_BY", LOG, e,
-                            e.getClass().getCanonicalName(), e.getMessage());
+                    e.getClass().getCanonicalName(), e.getMessage());
         }
     }
 
@@ -312,16 +313,6 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     public void setProperty(String prop, Object value) {
         if (Message.class.getName().equals(prop)) {
             message = (Message)value;
-        }
-    }
-
-    static class NUllOutputStream extends OutputStream {
-        public void write(byte[] b, int off, int len) {
-        }
-        public void write(int b) {
-        }
-
-        public void write(byte[] b) throws IOException {
         }
     }
 }

--- a/core/src/test/java/org/apache/cxf/databinding/source/XMLStreamDataReaderTest.java
+++ b/core/src/test/java/org/apache/cxf/databinding/source/XMLStreamDataReaderTest.java
@@ -19,27 +19,96 @@
 
 package org.apache.cxf.databinding.source;
 
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
+
+import org.w3c.dom.Document;
+import org.w3c.dom.ls.LSResourceResolver;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+
+
+import com.ctc.wstx.msv.W3CSchemaFactory;
+import com.sun.msv.reader.GrammarReaderController2;
+
+import org.apache.cxf.endpoint.Endpoint;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.ServiceImpl;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.service.model.MessagePartInfo;
+import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.staxutils.StaxUtils;
+import org.codehaus.stax2.XMLStreamReader2;
+import org.codehaus.stax2.validation.XMLValidationSchema;
 
+import org.easymock.EasyMock;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *
  */
 public class XMLStreamDataReaderTest {
     private static final byte[] DUMMY_DATA = "<ns:dummy xmlns:ns='http://www.apache.org/cxf'/>".getBytes();
+
+
+    static class LocalController implements GrammarReaderController2 {
+        @Override
+        public LSResourceResolver getLSResourceResolver() {
+            return null;
+        }
+
+        @Override
+        public void error(Locator[] locs, String errorMessage, Exception nestedException) {
+            StringBuffer errors = new StringBuffer();
+            for (Locator loc : locs) {
+                errors.append("in " + loc.getSystemId() + " " + loc.getLineNumber() + ":"
+                        + loc.getColumnNumber());
+            }
+            throw new RuntimeException(errors.toString(), nestedException);
+        }
+
+        @Override
+        public void warning(Locator[] locs, String errorMessage) {
+            StringBuffer errors = new StringBuffer();
+            for (Locator loc : locs) {
+                errors.append("in " + loc.getSystemId() + " " + loc.getLineNumber() + ":"
+                        + loc.getColumnNumber());
+            }
+            // no warning allowed.
+            throw new RuntimeException("warning: " + errors.toString());
+        }
+
+        @Override
+        public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+            return null;
+        }
+    }
 
     @Test
     public void testCloseOriginalInputStream() throws Exception {
@@ -61,6 +130,83 @@ public class XMLStreamDataReaderTest {
         ((XMLStreamReader)obj).close();
 
         assertTrue(in1.isClosed());
+    }
+
+    @Test
+    public void testValid() throws Exception {
+        testValidate("resources/schema.xsd", "resources/test-valid.xml", false);
+    }
+
+    @Test
+    public void testInValid() throws Exception {
+        testValidate("resources/schema.xsd", "resources/test-invalid.xml", true);
+    }
+
+
+    private void testValidate(String schemaPath, String xmlPath, boolean exceptionExpected) throws Exception {
+
+        //create schema
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        URL schemaURI = getClass().getResource(schemaPath);
+        Document wsdl = documentBuilder.parse(schemaURI.openStream());
+        String wsdlSystemId = schemaURI.toExternalForm();
+        DOMSource source = new DOMSource(wsdl);
+        source.setSystemId(wsdlSystemId);
+        source.setSystemId(wsdlSystemId);
+
+        XMLValidationSchema schemaw3c =
+                W3CSchemaFactory.newInstance(XMLValidationSchema.SCHEMA_ID_W3C_SCHEMA).createSchema(schemaURI);
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = schemaFactory.newSchema(schemaURI);
+
+        XMLStreamDataReader reader = new XMLStreamDataReader();
+        reader.setSchema(schema);
+
+
+        InputStream testIS = getClass().getResourceAsStream(xmlPath);
+        Message msg = new MessageImpl();
+        Exchange exchange = new ExchangeImpl();
+
+        ServiceInfo serviceInfo =  new ServiceInfo();
+
+        Endpoint endpoint = EasyMock.createMock(Endpoint.class);
+        EasyMock.expect(endpoint.isEmpty()).andAnswer(() -> false);
+        EasyMock.expect(endpoint.size()).andAnswer(() -> 1);
+        EasyMock.expect(endpoint.get(XMLValidationSchema.class.getName())).andAnswer(() -> schemaw3c);
+        EasyMock.replay(endpoint);
+
+
+        Service svc = new ServiceImpl(serviceInfo);
+
+        exchange.put(Service.class, svc);
+        exchange.put(Endpoint.class, endpoint);
+
+        msg.setExchange(exchange);
+        msg.setContent(InputStream.class, testIS);
+        reader.setProperty(Message.class.getName(), msg);
+
+        XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+        XMLStreamReader2 xmlStreamReader = (XMLStreamReader2) xmlFactory.createXMLStreamReader(testIS, "utf-8");
+
+        MessageInfo messageInfo = new MessageInfo(null,
+                MessageInfo.Type.INPUT,
+                new QName("http://www.test.org/services",
+                        "NullTestOperationRequest"));
+        MessagePartInfo messagePartInfo  = new MessagePartInfo(new QName(
+                "http://www.test.org/services", "NullTestOperationRequest"), messageInfo);
+        messagePartInfo.setElement(true);
+        boolean exceptionCaught = false;
+        try {
+            reader.read(messagePartInfo, xmlStreamReader);
+        } catch (Fault fault) {
+            exceptionCaught = true;
+        }  catch (Exception exc) {
+            fail(exc.getMessage());
+        }
+        assertEquals(exceptionExpected, exceptionCaught);
+
     }
 
     private static class TestInputStream extends ByteArrayInputStream {

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/schema.xsd
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/schema.xsd
@@ -1,0 +1,11 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.test.org/service/">
+    <xsd:element name="NullTestOperationRequest" nillable="true">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element nillable="true" name="inInt" type="xsd:int" maxOccurs="1" minOccurs="0" ></xsd:element>
+                <xsd:element nillable="true" name="inInteger" type="xsd:integer" maxOccurs="1" minOccurs="0" ></xsd:element>
+                <xsd:element nillable="true" name="inString" type="xsd:string" maxOccurs="1" minOccurs="0" ></xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/test-invalid.xml
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/test-invalid.xml
@@ -1,0 +1,5 @@
+<ser:NullTestOperationRequest xmlns:ser="http://www.test.org/service/">
+
+    <inInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="false"/>
+
+</ser:NullTestOperationRequest>

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/test-valid.xml
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/test-valid.xml
@@ -1,0 +1,7 @@
+<ser:NullTestOperationRequest xmlns:ser="http://www.test.org/service/">
+
+    <inInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    <inInteger xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    <inString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+
+</ser:NullTestOperationRequest>

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -90,7 +90,7 @@
         <bundle start-level="30" dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/${cxf.xmlschema.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${cxf.xmlresolver.bundle.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.fastinfoset/${cxf.fastinfoset.bundle.version}</bundle>
-        <bundle start-level="40">mvn:org.apache.cxf/cxf-core/${upstream.version}</bundle>
+        <bundle start-level="40">mvn:org.apache.cxf/cxf-core/${cxf-core.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-management/${upstream.version}</bundle>
         <conditional>
             <condition>shell</condition>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.4</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.4.20221020</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.4.20221103</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.4.20220422</cxf-services-xkms.features.tesb.version>
 
         <cxf-rt-ws-security.tesb.version>3.4.4.tesb1</cxf-rt-ws-security.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,10 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.4</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.4.20221103</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.4.20221020</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.4.20220422</cxf-services-xkms.features.tesb.version>
 
+        <cxf-core.tesb.version>3.4.4.20221108</cxf-core.tesb.version>
         <cxf-rt-ws-security.tesb.version>3.4.4.tesb1</cxf-rt-ws-security.tesb.version>
         <cxf-services-wsn-core.tesb.version>3.4.4.tesb1</cxf-services-wsn-core.tesb.version>
         <cxf-rt-features-logging.tesb.version>3.4.4.20220520</cxf-rt-features-logging.tesb.version>
@@ -456,6 +457,7 @@
                             -->
                             <apache-cxf.features.tesb.version>${apache-cxf.features.tesb.version}</apache-cxf.features.tesb.version>
                             <cxf-services-xkms.features.tesb.version>${cxf-services-xkms.features.tesb.version}</cxf-services-xkms.features.tesb.version>
+                            <cxf-core.tesb.version>${cxf-core.tesb.version}</cxf-core.tesb.version>
                             <cxf-rt-ws-security.tesb.version>${cxf-rt-ws-security.tesb.version}</cxf-rt-ws-security.tesb.version>
                             <cxf-rt-features-logging.tesb.version>${cxf-rt-features-logging.tesb.version}</cxf-rt-features-logging.tesb.version>
                             <cxf.jakarta.mail.version.tesb.version>${cxf.jakarta.mail.version.tesb.version}</cxf.jakarta.mail.version.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.4</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.4.20221020</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.4.20221108</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.4.20220422</cxf-services-xkms.features.tesb.version>
 
         <cxf-core.tesb.version>3.4.4.20221108</cxf-core.tesb.version>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Validation of nillable tags fails in ESB Runtime
ex : <inInteger xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>

**What is the chosen solution to this problem?**

Change xml validation strategy to use the Woodstox validation when reading instead of having a reader and a writer to a nulloutput.

This method is not able to handle the xsi:nil=true attributes.

Old algorithm :
 - Transform the input to a DOMSource Object
 - create a XMLReader from this new object and a XMLWriter to a nulloutput
 - setup the wookdstock validation on the writer if possible
    - Create a filtered Reader to remove external references
    - Copy the filterReader to the Null Writer
 - if setup fails, use XOP validation

New algorithm:
  - create a filtered reader from the input to remove external references
  - setup the wookdstock validation on the *reader* if possible
    - call read
  - if setup fails, use XOP validation

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPRUN-4595

**Check if the PR fulfills these requirements:**

- [x] The PR commit message follows our [Guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
- [x] Enough logs are present and are well formatted (to facilitate bug analysis) if applicable
