### PR TITLE
fix(TPRUN-4595) : Part2 , Change xml validation strategy 

### DIFF
--- a/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
+++ b/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
@@ -215,11 +215,14 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     }
 
     private Element validate(XMLStreamReader input) throws XMLStreamException, IOException {
+
         Element rootElement;
         WoodstoxValidationImpl impl = new WoodstoxValidationImpl();
+        XMLStreamReader input2 = null;
         if (impl.canValidate()) {
 
-            impl.setupValidation(input, message.getExchange().getEndpoint(),
+            input2 = StaxUtils.createXMLStreamReader(getInputStream(input));
+            impl.setupValidation(input2, message.getExchange().getEndpoint(),
                     message.getExchange().getService().getServiceInfos().get(0));
         }
         //check if the impl can still validate after the setup, possible issue loading schemas or similar
@@ -229,7 +232,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             //filter xop node
 
             XMLStreamReader filteredReader =
-                    StaxUtils.createFilteredReader(input,
+                    StaxUtils.createFilteredReader(input2,
                             new StaxStreamFilter(new QName[] {XOP}));
 
             rootElement =  StaxUtils.read(filteredReader).getDocumentElement();
@@ -242,7 +245,6 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             } else {
                 rootElement = (Element)ds.getNode();
             }
-
 
             //MSV not available, use a slower method of cloning the data, replace the xop's, validate
             LOG.fine("NO_MSV_AVAILABLE");

--- a/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
+++ b/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
@@ -236,6 +236,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
                             new StaxStreamFilter(new QName[] {XOP}));
 
             rootElement =  StaxUtils.read(filteredReader).getDocumentElement();
+            filteredReader.close();
 
         } else {
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.4</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.4.20221108</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.4.20221114</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.4.20220422</cxf-services-xkms.features.tesb.version>
 
-        <cxf-core.tesb.version>3.4.4.20221108</cxf-core.tesb.version>
+        <cxf-core.tesb.version>3.4.4.20221114</cxf-core.tesb.version>
         <cxf-rt-ws-security.tesb.version>3.4.4.tesb1</cxf-rt-ws-security.tesb.version>
         <cxf-services-wsn-core.tesb.version>3.4.4.tesb1</cxf-services-wsn-core.tesb.version>
         <cxf-rt-features-logging.tesb.version>3.4.4.20220520</cxf-rt-features-logging.tesb.version>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Validation of nillable tags fails in ESB Runtime
ex : <inInteger xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>

First attempt to fix it in pull request https://github.com/Talend/cxf/pull/40 was unsucessful

**What is the chosen solution to this problem?**

Change xml validation strategy to use the Woodstox validation when reading instead of having a reader and a writer to a nulloutput.

This method is not able to handle the xsi:nil=true attributes.

Old algorithm :
 - Transform the input to a DOMSource Object
 - create a XMLReader from this new object and a XMLWriter to a nulloutput
 - setup the wookdstock validation on the writer if possible
    - Create a filtered Reader to remove external references
    - Copy the filterReader to the Null Writer
 - if setup fails, use XOP validation

New algorithm:
  - create a filtered reader from the input to remove external references
  - setup the wookdstock validation on the *reader* if possible
    - call read
  - if setup fails, use XOP validation

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPRUN-4595

**Check if the PR fulfills these requirements:**

- [x] The PR commit message follows our [Guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
- [x] Enough logs are present and are well formatted (to facilitate bug analysis) if applicable
