### PR TITLE
fix(TPRUN-4800) : upgrade karaf version to 4.4.3

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,6 +1,6 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features',
+        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features',
         USE_JAVA11: 'true'
 )

--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,6 +1,6 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features',
+        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core',
         USE_JAVA11: 'true'
 )

--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,6 +1,6 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core',
+        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features',
         USE_JAVA11: 'true'
 )

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,6 +24,7 @@
     <name>Apache CXF Core</name>
     <description>Apache CXF Core</description>
     <url>https://cxf.apache.org</url>
+    <version>${revision}</version>
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
@@ -31,6 +32,7 @@
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <revision>${cxf-core.tesb.version}</revision>
         <cxf.module.name>org.apache.cxf.core</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.bus.osgi.CXFActivator</cxf.bundle.activator>
         <cxf.osgi.export>

--- a/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
+++ b/core/src/main/java/org/apache/cxf/databinding/source/XMLStreamDataReader.java
@@ -29,7 +29,6 @@ import javax.activation.DataSource;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
@@ -118,7 +117,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             if (type != null) {
                 Object retVal = null;
                 if (SAXSource.class.isAssignableFrom(type)
-                    || StaxSource.class.isAssignableFrom(type)) {
+                        || StaxSource.class.isAssignableFrom(type)) {
                     retVal = new StaxSource(resetForStreaming(input));
                 } else if (StreamSource.class.isAssignableFrom(type)) {
                     retVal = new StreamSource(getInputStream(input));
@@ -160,7 +159,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             throw new Fault("COULD_NOT_READ_XML_STREAM", LOG, e);
         } catch (XMLStreamException e) {
             throw new Fault("COULD_NOT_READ_XML_STREAM_CAUSED_BY", LOG, e,
-                            e.getMessage());
+                     e.getMessage());
         }
     }
 
@@ -216,41 +215,45 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     }
 
     private Element validate(XMLStreamReader input) throws XMLStreamException, IOException {
-        DOMSource ds = read(input);
-        final Element rootElement;
-        if (ds.getNode() instanceof Document) {
-            rootElement = ((Document)ds.getNode()).getDocumentElement();
-        } else {
-            rootElement = (Element)ds.getNode();
-        }
-
+        Element rootElement;
         WoodstoxValidationImpl impl = new WoodstoxValidationImpl();
-        XMLStreamWriter nullWriter = null;
+        XMLStreamReader input2 = null;
         if (impl.canValidate()) {
-            nullWriter = StaxUtils.createXMLStreamWriter(new NUllOutputStream());
-            impl.setupValidation(nullWriter, message.getExchange().getEndpoint(),
-                                 message.getExchange().getService().getServiceInfos().get(0));
+
+            input2 = StaxUtils.createXMLStreamReader(getInputStream(input));
+            impl.setupValidation(input2, message.getExchange().getEndpoint(),
+                    message.getExchange().getService().getServiceInfos().get(0));
         }
         //check if the impl can still validate after the setup, possible issue loading schemas or similar
         if (impl.canValidate()) {
             //Can use the MSV libs and woodstox to handle the schema validation during
             //parsing and processing.   Much faster and single traversal
             //filter xop node
-            XMLStreamReader reader = StaxUtils.createXMLStreamReader(ds);
-            XMLStreamReader filteredReader =
-                StaxUtils.createFilteredReader(reader,
-                                               new StaxStreamFilter(new QName[] {XOP}));
 
-            StaxUtils.copy(filteredReader, nullWriter);
+            XMLStreamReader filteredReader =
+                    StaxUtils.createFilteredReader(input2,
+                            new StaxStreamFilter(new QName[] {XOP}));
+
+            rootElement =  StaxUtils.read(filteredReader).getDocumentElement();
+            filteredReader.close();
+
         } else {
+
+            DOMSource ds = read(input);
+            if (ds.getNode() instanceof Document) {
+                rootElement = ((Document)ds.getNode()).getDocumentElement();
+            } else {
+                rootElement = (Element)ds.getNode();
+            }
+
             //MSV not available, use a slower method of cloning the data, replace the xop's, validate
             LOG.fine("NO_MSV_AVAILABLE");
             Element newElement = rootElement;
             if (DOMUtils.hasElementWithName(rootElement, "http://www.w3.org/2004/08/xop/include", "Include")) {
                 newElement = (Element)rootElement.cloneNode(true);
                 List<Element> elems = DOMUtils.findAllElementsByTagNameNS(newElement,
-                                                                          "http://www.w3.org/2004/08/xop/include",
-                                                                          "Include");
+                        "http://www.w3.org/2004/08/xop/include",
+                        "Include");
                 for (Element include : elems) {
                     Node parentNode = include.getParentNode();
                     parentNode.removeChild(include);
@@ -269,7 +272,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     }
 
     private InputStream getInputStream(XMLStreamReader input)
-        throws XMLStreamException, IOException {
+            throws XMLStreamException, IOException {
 
         try (CachedOutputStream out = new CachedOutputStream()) {
             StaxUtils.copy(input, out);
@@ -298,7 +301,7 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
             return new DOMSource(document);
         } catch (XMLStreamException e) {
             throw new Fault("COULD_NOT_READ_XML_STREAM_CAUSED_BY", LOG, e,
-                            e.getMessage());
+                     e.getMessage());
         }
     }
 
@@ -312,16 +315,6 @@ public class XMLStreamDataReader implements DataReader<XMLStreamReader> {
     public void setProperty(String prop, Object value) {
         if (Message.class.getName().equals(prop)) {
             message = (Message)value;
-        }
-    }
-
-    static class NUllOutputStream extends OutputStream {
-        public void write(byte[] b, int off, int len) {
-        }
-        public void write(int b) {
-        }
-
-        public void write(byte[] b) throws IOException {
         }
     }
 }

--- a/core/src/test/java/org/apache/cxf/databinding/source/XMLStreamDataReaderTest.java
+++ b/core/src/test/java/org/apache/cxf/databinding/source/XMLStreamDataReaderTest.java
@@ -22,27 +22,89 @@ package org.apache.cxf.databinding.source;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.ls.LSResourceResolver;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+
+import com.ctc.wstx.msv.W3CSchemaFactory;
+import com.sun.msv.reader.GrammarReaderController2;
+
+import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Exchange;
+import org.apache.cxf.message.ExchangeImpl;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.service.Service;
+import org.apache.cxf.service.ServiceImpl;
+import org.apache.cxf.service.model.MessageInfo;
+import org.apache.cxf.service.model.MessagePartInfo;
+import org.apache.cxf.service.model.ServiceInfo;
 import org.apache.cxf.staxutils.StaxUtils;
+import org.codehaus.stax2.XMLStreamReader2;
+import org.codehaus.stax2.validation.XMLValidationSchema;
 
+import org.easymock.EasyMock;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *
  */
 public class XMLStreamDataReaderTest {
     private static final byte[] DUMMY_DATA = "<ns:dummy xmlns:ns='http://www.apache.org/cxf'/>".getBytes();
-    private static final byte[] DUMMY_DATA_NULL_BYTE =
-        "<ns:dummy xmlns:ns='http://www.apache.org/cxf&#x00;'/>".getBytes();
+
+    static class LocalController implements GrammarReaderController2 {
+        @Override
+        public LSResourceResolver getLSResourceResolver() {
+            return null;
+        }
+
+        @Override
+        public void error(Locator[] locs, String errorMessage, Exception nestedException) {
+            StringBuffer errors = new StringBuffer();
+            for (Locator loc : locs) {
+                errors.append("in " + loc.getSystemId() + " " + loc.getLineNumber() + ":"
+                        + loc.getColumnNumber());
+            }
+            throw new RuntimeException(errors.toString(), nestedException);
+        }
+
+        @Override
+        public void warning(Locator[] locs, String errorMessage) {
+            StringBuffer errors = new StringBuffer();
+            for (Locator loc : locs) {
+                errors.append("in " + loc.getSystemId() + " " + loc.getLineNumber() + ":"
+                        + loc.getColumnNumber());
+            }
+            // no warning allowed.
+            throw new RuntimeException("warning: " + errors.toString());
+        }
+
+        @Override
+        public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+            return null;
+        }
+    }
 
     @Test
     public void testCloseOriginalInputStream() throws Exception {
@@ -66,30 +128,80 @@ public class XMLStreamDataReaderTest {
         assertTrue(in1.isClosed());
     }
 
-    // Parse some XML with a null byte and check we don't return internal Woodstox package names in the error message
     @Test
-    public void testParseNullByte() throws Exception {
+    public void testValid() throws Exception {
+        testValidate("resources/schema.xsd", "resources/test-valid.xml", false);
+    }
+
+    @Test
+    public void testInValid() throws Exception {
+        testValidate("resources/schema.xsd", "resources/test-invalid.xml", true);
+    }
+
+
+    private void testValidate(String schemaPath, String xmlPath, boolean exceptionExpected) throws Exception {
+
+        //create schema
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        URL schemaURI = getClass().getResource(schemaPath);
+        Document wsdl = documentBuilder.parse(schemaURI.openStream());
+        String wsdlSystemId = schemaURI.toExternalForm();
+        DOMSource source = new DOMSource(wsdl);
+        source.setSystemId(wsdlSystemId);
+        source.setSystemId(wsdlSystemId);
+
+        XMLValidationSchema schemaw3c =
+                W3CSchemaFactory.newInstance(XMLValidationSchema.SCHEMA_ID_W3C_SCHEMA).createSchema(schemaURI);
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = schemaFactory.newSchema(schemaURI);
+
         XMLStreamDataReader reader = new XMLStreamDataReader();
+        reader.setSchema(schema);
+
+
+        InputStream testIS = getClass().getResourceAsStream(xmlPath);
         Message msg = new MessageImpl();
+        Exchange exchange = new ExchangeImpl();
 
-        TestInputStream in1 = new TestInputStream(DUMMY_DATA_NULL_BYTE);
+        ServiceInfo serviceInfo =  new ServiceInfo();
 
-        msg.setContent(InputStream.class, in1);
+        Endpoint endpoint = EasyMock.createMock(Endpoint.class);
+        EasyMock.expect(endpoint.isEmpty()).andAnswer(() -> false);
+        EasyMock.expect(endpoint.size()).andAnswer(() -> 1);
+        EasyMock.expect(endpoint.get(XMLValidationSchema.class.getName())).andAnswer(() -> schemaw3c);
+        EasyMock.replay(endpoint);
 
+
+        Service svc = new ServiceImpl(serviceInfo);
+
+        exchange.put(Service.class, svc);
+        exchange.put(Endpoint.class, endpoint);
+
+        msg.setExchange(exchange);
+        msg.setContent(InputStream.class, testIS);
         reader.setProperty(Message.class.getName(), msg);
 
-        Object obj = reader.read(new QName("http://www.apache.org/cxf", "dummy"),
-                StaxUtils.createXMLStreamReader(in1), XMLStreamReader.class);
+        XMLInputFactory xmlFactory = XMLInputFactory.newInstance();
+        XMLStreamReader2 xmlStreamReader = (XMLStreamReader2) xmlFactory.createXMLStreamReader(testIS, "utf-8");
 
-        assertTrue(obj instanceof XMLStreamReader);
-
+        MessageInfo messageInfo = new MessageInfo(null,
+                MessageInfo.Type.INPUT,
+                new QName("http://www.test.org/services",
+                        "NullTestOperationRequest"));
+        MessagePartInfo messagePartInfo  = new MessagePartInfo(new QName(
+                "http://www.test.org/services", "NullTestOperationRequest"), messageInfo);
+        messagePartInfo.setElement(true);
+        boolean exceptionCaught = false;
         try {
-            reader.read((XMLStreamReader) obj);
-        } catch (Fault f) {
-            assertFalse(f.getMessage().contains("com.ctc.wstx"));
+            reader.read(messagePartInfo, xmlStreamReader);
+        } catch (Fault fault) {
+            exceptionCaught = true;
+        }  catch (Exception exc) {
+            fail(exc.getMessage());
         }
-
-        ((XMLStreamReader)obj).close();
+        assertEquals(exceptionExpected, exceptionCaught);
     }
 
     private static class TestInputStream extends ByteArrayInputStream {

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/schema.xsd
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/schema.xsd
@@ -1,0 +1,11 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.test.org/service/">
+    <xsd:element name="NullTestOperationRequest" nillable="true">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element nillable="true" name="inInt" type="xsd:int" maxOccurs="1" minOccurs="0" ></xsd:element>
+                <xsd:element nillable="true" name="inInteger" type="xsd:integer" maxOccurs="1" minOccurs="0" ></xsd:element>
+                <xsd:element nillable="true" name="inString" type="xsd:string" maxOccurs="1" minOccurs="0" ></xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/test-invalid.xml
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/test-invalid.xml
@@ -1,0 +1,5 @@
+<ser:NullTestOperationRequest xmlns:ser="http://www.test.org/service/">
+
+    <inInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="false"/>
+
+</ser:NullTestOperationRequest>

--- a/core/src/test/java/org/apache/cxf/databinding/source/resources/test-valid.xml
+++ b/core/src/test/java/org/apache/cxf/databinding/source/resources/test-valid.xml
@@ -1,0 +1,7 @@
+<ser:NullTestOperationRequest xmlns:ser="http://www.test.org/service/">
+
+    <inInt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    <inInteger xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+    <inString xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+
+</ser:NullTestOperationRequest>

--- a/osgi/bundle/compatible/pom.xml
+++ b/osgi/bundle/compatible/pom.xml
@@ -24,12 +24,14 @@
     <name>Apache CXF Compatibility Bundle Jar</name>
     <description>Apache CXF Compatibility Bundle Jar</description>
     <url>https://cxf.apache.org</url>
+    <version>${revision}</version>
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-bundle-parent</artifactId>
         <version>3.5.5</version>
     </parent>
     <properties>
+        <revision>${cxf-bundle-compatible.tesb.version}</revision>
         <cxf.osgi.symbolic.name>${project.groupId}.bundle</cxf.osgi.symbolic.name>
         <cxf.module.name>org.apache.cxf.bundle</cxf.module.name>
     </properties>
@@ -186,7 +188,7 @@
                             org.springframework*;resolution:=optional;version="[2.5,4)",
                             javax.activation;version="[0.0,2)",
                             javax.annotation;version="[0.0,2)",
-                            javax.jms;resolution:=optional;version="[0.0,2)",
+                            javax.jms;resolution:=optional;version="[0.0,3)",
                             javax.jws*;version="[0.0,3)",
                             javax.mail*;version="[0.0,2)",
                             javax.servlet.*;version="[0.0,4)";resolution:=optional,

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -45,6 +45,19 @@
         <bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${cxf.jaxb.bundle.version}</bundle>
         <bundle start-level="20">mvn:com.sun.istack/istack-commons-runtime/${cxf.istack.bundle.version}</bundle>
     </feature>
+    <feature name="cxf-abdera" version="${upstream.version}">
+        <feature version="${upstream.version}">cxf-specs</feature>
+        <bundle start-level="25" dependency="true">mvn:commons-codec/commons-codec/${cxf.commons-codec.version}</bundle>
+        <bundle start-level="35">mvn:org.apache.abdera/abdera-core/${cxf.abdera.version}</bundle>
+        <bundle start-level="35">mvn:org.apache.abdera/abdera-extensions-main/${cxf.abdera.version}</bundle>
+        <bundle start-level="35">mvn:org.apache.abdera/abdera-i18n/${cxf.abdera.version}</bundle>
+        <bundle start-level="35">mvn:org.apache.james/apache-mime4j-core/${cxf.james.mim4j.version}</bundle>
+        <bundle start-level="35">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.abdera-parser/${cxf.abdera.osgi.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/${cxf.jdom.bundle.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${cxf.dom4j.bundle.version}</bundle>
+        <!--bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-html/${cxf.abdera.version}</bundle>
+        <bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-json/${cxf.abdera.version}</bundle>-->
+    </feature>
     <feature name="saaj-impl" version="${cxf.saaj-impl.version}">
         <bundle start-level="25">mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}</bundle>
         <bundle start-level="25">mvn:com.sun.xml.messaging.saaj/saaj-impl/${cxf.saaj-impl.version}</bundle>

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -44,20 +44,6 @@
         <bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${cxf.jaxb.bundle.version}</bundle>
         <bundle start-level="20">mvn:com.sun.istack/istack-commons-runtime/${cxf.istack.bundle.version}</bundle>
     </feature>
-    <!-- Current the abdera bundle is not working as we expect -->
-    <feature name="cxf-abdera" version="${upstream.version}">
-        <feature version="${upstream.version}">cxf-specs</feature>
-        <bundle start-level="25" dependency="true">mvn:commons-codec/commons-codec/${cxf.commons-codec.version}</bundle>
-        <bundle start-level="35">mvn:org.apache.abdera/abdera-core/${cxf.abdera.version}</bundle>
-        <bundle start-level="35">mvn:org.apache.abdera/abdera-extensions-main/${cxf.abdera.version}</bundle>
-        <bundle start-level="35">mvn:org.apache.abdera/abdera-i18n/${cxf.abdera.version}</bundle>
-        <bundle start-level="35">mvn:org.apache.james/apache-mime4j-core/${cxf.james.mim4j.version}</bundle>
-        <bundle start-level="35">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.abdera-parser/${cxf.abdera.osgi.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/${cxf.jdom.bundle.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/${cxf.dom4j.bundle.version}</bundle>
-        <!--bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-html/${cxf.abdera.version}</bundle>
-        <bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-json/${cxf.abdera.version}</bundle>-->
-    </feature>
     <feature name="saaj-impl" version="${cxf.saaj-impl.version}">
         <bundle start-level="25">mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}</bundle>
         <bundle start-level="25">mvn:com.sun.xml.messaging.saaj/saaj-impl/${cxf.saaj-impl.version}</bundle>
@@ -90,6 +76,7 @@
         <bundle start-level="30" dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/${cxf.xmlschema.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${cxf.xmlresolver.bundle.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.fastinfoset/${cxf.fastinfoset.bundle.version}</bundle>
+        <bundle start-level="30" dependency="true">mvn:${cxf.asm.groupId}/${cxf.asm.artifactId}/${cxf.asm.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-core/${upstream.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-management/${upstream.version}</bundle>
         <conditional>
@@ -192,6 +179,9 @@
     <feature name="cxf-http-netty-client" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-http</feature>
         <bundle dependency="true" start-level="40">mvn:${cxf.servlet-api.group}/${cxf.servlet-api.artifact}/${cxf.servlet-api.version}</bundle>
+        <bundle start-level="40">mvn:org.bouncycastle/bcprov-jdk15on/${cxf.bcprov.version}</bundle>
+        <bundle start-level="40">mvn:org.bouncycastle/bcutil-jdk15on/${cxf.bcprov.version}</bundle>
+        <bundle start-level="40">mvn:org.bouncycastle/bctls-jdk15on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-tcnative-classes/${cxf.netty.tcnative.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
@@ -205,6 +195,9 @@
     </feature>
     <feature name="cxf-http-netty-server" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-http</feature>
+        <bundle start-level="40">mvn:org.bouncycastle/bcprov-jdk15on/${cxf.bcprov.version}</bundle>
+        <bundle start-level="40">mvn:org.bouncycastle/bcutil-jdk15on/${cxf.bcprov.version}</bundle>
+        <bundle start-level="40">mvn:org.bouncycastle/bctls-jdk15on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-tcnative-classes/${cxf.netty.tcnative.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
@@ -221,7 +214,7 @@
     </feature>
     <feature name="cxf-http-undertow" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-http</feature>
-        <feature>pax-http-undertow</feature>
+        <feature>pax-web-http-undertow</feature>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-undertow/${upstream.version}</bundle>
         <capability>
             cxf.http.provider;name=undertow
@@ -536,6 +529,7 @@
         <feature version="${upstream.version}">cxf-wsn-api</feature>
         <feature version="${upstream.version}">cxf-http-provider</feature>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aopalliance/1.0_6</bundle>
+        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${cxf.geronimo.jta.version}</bundle>
         <!-- <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${cxf.geronimo.jms.version}</bundle> -->
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_2.0_spec/${cxf.geronimo.jms2.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-j2ee-management_1.1_spec/${cxf.geronimo.j2ee.management.version}</bundle>

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -31,6 +31,7 @@
         <bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.4/1.4_1</bundle>
         <bundle start-level="10" dependency="true">mvn:jakarta.jws/jakarta.jws-api/${cxf.jakarta.jwsapi.version}</bundle>
         <bundle start-level="10" dependency="true">mvn:jakarta.mail/jakarta.mail-api/${cxf.jakarta.mail.version}</bundle>
+        <!-- <bundle start-level="10" dependency="true">mvn:com.sun.mail/jakarta.mail/${cxf.jakarta.mail.tesb.version}</bundle> -->
         <bundle start-level="20" dependency="true">mvn:org.codehaus.woodstox/stax2-api/${cxf.woodstox.stax2-api.version}</bundle>
         <bundle start-level="20">mvn:com.fasterxml.woodstox/woodstox-core/${cxf.woodstox.core.version}</bundle>
         <bundle start-level="20">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/${cxf.jaxb.bundle.version}</bundle>
@@ -77,7 +78,7 @@
         <bundle start-level="25" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${cxf.xmlresolver.bundle.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.fastinfoset/${cxf.fastinfoset.bundle.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:${cxf.asm.groupId}/${cxf.asm.artifactId}/${cxf.asm.version}</bundle>
-        <bundle start-level="40">mvn:org.apache.cxf/cxf-core/${upstream.version}</bundle>
+        <bundle start-level="40">mvn:org.apache.cxf/cxf-core/${cxf-core.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-management/${upstream.version}</bundle>
         <conditional>
             <condition>shell</condition>
@@ -126,6 +127,7 @@
         <feature version="${upstream.version}">cxf-ws-addr</feature>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${cxf.geronimo.jta.version}</bundle>
         <bundle start-level="40" dependency="true">mvn:org.ehcache/ehcache/${cxf.ehcache3.version}</bundle>
+        <!-- <bundle start-level="40" dependency="true">wrap:mvn:org.ehcache/ehcache/${cxf.ehcache3.version}$overwrite=merge&amp;Import-Package=javax.xml.bind*,*;resolution:=optional</bundle> -->
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-ws-security/${upstream.version}</bundle>
     </feature>
     <feature name="cxf-rt-security" version="${upstream.version}">
@@ -183,14 +185,14 @@
         <bundle start-level="40">mvn:org.bouncycastle/bcutil-jdk15on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:org.bouncycastle/bctls-jdk15on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-tcnative-classes/${cxf.netty.tcnative.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-netty-client/${upstream.version}</bundle>
     </feature>
     <feature name="cxf-http-netty-server" version="${upstream.version}">
@@ -199,14 +201,14 @@
         <bundle start-level="40">mvn:org.bouncycastle/bcutil-jdk15on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:org.bouncycastle/bctls-jdk15on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-tcnative-classes/${cxf.netty.tcnative.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-netty-server/${upstream.version}</bundle>
         <capability>
             cxf.http.provider;name=netty
@@ -239,7 +241,7 @@
         <feature version="${upstream.version}">cxf-http</feature>
         <feature version="${upstream.version}">cxf-jackson</feature>
         <feature version="${upstream.version}">cxf-rt-security</feature>
-        <bundle start-level="30" dependency="true">mvn:org.codehaus.jettison/jettison/${cxf.jettison.version}</bundle>
+        <bundle start-level="30" dependency="true">mvn:org.codehaus.jettison/jettison/${cxf.jettison.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-extension-providers/${upstream.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-extension-search/${upstream.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-json-basic/${upstream.version}</bundle>
@@ -399,18 +401,18 @@
         <feature version="${upstream.version}">cxf-http</feature>
         <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client/${cxf.ahc.version}</bundle>
         <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client-netty-utils/${cxf.ahc.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-handler/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-buffer/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-resolver/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport-native-kqueue/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${cxf.netty.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-common/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-handler/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-buffer/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-resolver/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-kqueue/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${cxf.netty.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${cxf.reactivestreams.version}</bundle>
         <bundle dependency='true'>mvn:com.typesafe.netty/netty-reactive-streams/2.0.4</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-websocket/${upstream.version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -251,7 +251,7 @@
         <cxf.jaxb.bundle.version>2.3.2_1</cxf.jaxb.bundle.version>
         <cxf.jaxb.context.class.property>none</cxf.jaxb.context.class.property>
         <cxf.jdom.bundle.version>1.1_4</cxf.jdom.bundle.version>
-        <cxf.karaf.version>4.3.8</cxf.karaf.version>
+        <cxf.karaf.version>4.4.3</cxf.karaf.version>
         <cxf.oauth.bundle.version>20100527_1</cxf.oauth.bundle.version>
         <cxf.oro.bundle.version>2.0.8_6</cxf.oro.bundle.version>
         <cxf.osgi.saaj.version>[1.4,2)</cxf.osgi.saaj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,11 @@
     </issueManagement>
     <properties>
         <upstream.version>3.5.5</upstream.version>
-        <apache-cxf.features.tesb.version>3.5.5.20230201</apache-cxf.features.tesb.version>
-        <cxf-services-xkms.features.tesb.version>3.5.5.20230201</cxf-services-xkms.features.tesb.version>
-        <cxf-core.tesb.version>3.5.5.20230201</cxf-core.tesb.version>
-        <cxf-services-wsn-core.tesb.version>3.5.5.20230201</cxf-services-wsn-core.tesb.version>
-        <cxf-bundle-compatible.tesb.version>3.5.5.20230201</cxf-bundle-compatible.tesb.version>
+        <apache-cxf.features.tesb.version>3.5.5.20230330</apache-cxf.features.tesb.version>
+        <cxf-services-xkms.features.tesb.version>3.5.5.20230330</cxf-services-xkms.features.tesb.version>
+        <cxf-core.tesb.version>3.5.5.20230330</cxf-core.tesb.version>
+        <cxf-services-wsn-core.tesb.version>3.5.5.20230330</cxf-services-wsn-core.tesb.version>
+        <cxf-bundle-compatible.tesb.version>3.5.5.20230330</cxf-bundle-compatible.tesb.version>
         <!-- <cxf.jakarta.mail.tesb.version>1.6.7</cxf.jakarta.mail.tesb.version> -->
         <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
         <cxf.netty.tesb.version>4.1.89.Final</cxf.netty.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <properties>
         <upstream.version>3.5.5</upstream.version>
         <apache-cxf.features.tesb.version>3.5.5.20230201</apache-cxf.features.tesb.version>
-        <cxf-services-xkms.features.tesb.version>3.4.10.20221230</cxf-services-xkms.features.tesb.version>
-        <cxf-services-wsn-core.tesb.version>3.4.10.20221230</cxf-services-wsn-core.tesb.version>
+        <cxf-services-xkms.features.tesb.version>3.5.5.20230201</cxf-services-xkms.features.tesb.version>
+        <cxf-services-wsn-core.tesb.version>3.5.5.20230201</cxf-services-wsn-core.tesb.version>
 	    <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
         <cxf.compiler.fork>false</cxf.compiler.fork>
         <cxf.build-utils.version>3.4.4</cxf.build-utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,14 @@
         <upstream.version>3.5.5</upstream.version>
         <apache-cxf.features.tesb.version>3.5.5.20230201</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.5.5.20230201</cxf-services-xkms.features.tesb.version>
+        <cxf-core.tesb.version>3.5.5.20230201</cxf-core.tesb.version>
         <cxf-services-wsn-core.tesb.version>3.5.5.20230201</cxf-services-wsn-core.tesb.version>
-	    <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
+        <cxf-bundle-compatible.tesb.version>3.5.5.20230201</cxf-bundle-compatible.tesb.version>
+        <!-- <cxf.jakarta.mail.tesb.version>1.6.7</cxf.jakarta.mail.tesb.version> -->
+        <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
+        <cxf.netty.tesb.version>4.1.89.Final</cxf.netty.tesb.version>
+        <cxf.jettison.tesb.version>1.5.4</cxf.jettison.tesb.version>
+
         <cxf.compiler.fork>false</cxf.compiler.fork>
         <cxf.build-utils.version>3.4.4</cxf.build-utils.version>
         <cxf.xjc-utils.version>3.3.2</cxf.xjc-utils.version>
@@ -443,8 +449,13 @@
                             -->
                             <apache-cxf.features.tesb.version>${apache-cxf.features.tesb.version}</apache-cxf.features.tesb.version>
                             <cxf-services-xkms.features.tesb.version>${cxf-services-xkms.features.tesb.version}</cxf-services-xkms.features.tesb.version>
+                            <cxf-core.tesb.version>${cxf-core.tesb.version}</cxf-core.tesb.version>
                             <cxf-services-wsn-core.tesb.version>${cxf-services-wsn-core.tesb.version}</cxf-services-wsn-core.tesb.version>
+                            <cxf-bundle-compatible.tesb.version>${cxf-bundle-compatible.tesb.version}</cxf-bundle-compatible.tesb.version>
+                            <!-- <cxf.jakarta.mail.tesb.version>${cxf.jakarta.mail.tesb.version}</cxf.jakarta.mail.tesb.version> -->
                             <cxf.geronimo.jms2.tesb.version>${cxf.geronimo.jms2.tesb.version}</cxf.geronimo.jms2.tesb.version>
+                            <cxf.netty.tesb.version>${cxf.netty.tesb.version}</cxf.netty.tesb.version>
+                            <cxf.jettison.tesb.version>${cxf.jettison.tesb.version}</cxf.jettison.tesb.version>
                         </properties>
                     </configuration>
                     <executions>

--- a/services/xkms/xkms-features/pom.xml
+++ b/services/xkms/xkms-features/pom.xml
@@ -24,6 +24,7 @@
     <packaging>pom</packaging>
     <name>Apache CXF XKMS Karaf Features</name>
     <url>https://cxf.apache.org</url>
+    <version>${revision}</version>
     <parent>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-parent</artifactId>
@@ -31,6 +32,7 @@
         <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
     <properties>
+        <revision>${cxf-services-xkms.features.tesb.version}</revision>
         <cxf.module.name>org.apache.cxf.xkms.features</cxf.module.name>
     </properties>
     <build>

--- a/services/xkms/xkms-features/src/main/resources/features.xml
+++ b/services/xkms/xkms-features/src/main/resources/features.xml
@@ -25,6 +25,7 @@
         <feature>cxf-http</feature>
         <feature>cxf-ws-security</feature>
         <bundle start-level="40" dependency="true">mvn:org.ehcache/ehcache/${cxf.ehcache3.version}</bundle>
+        <!-- <bundle start-level="40" dependency="true">wrap:mvn:org.ehcache/ehcache/${cxf.ehcache3.version}$overwrite=merge&amp;Import-Package=javax.xml.bind*,*;resolution:=optional</bundle> -->
         <bundle>mvn:${project.groupId}/cxf-services-xkms-common/${upstream.version}</bundle>
         <!-- <bundle>mvn:${project.groupId}/cxf-services-xkms-client/${upstream.version}</bundle> -->
         <bundle>wrap:mvn:${project.groupId}/cxf-services-xkms-client/${upstream.version}$overwrite=merge&amp;Import-Package=*,redis.clients.jedis;resolution:=optional</bundle>


### PR DESCRIPTION
🏁 **Context (Jira, design, ...)**
- https://jira.talendforge.org/browse/TPRUN-4800

🔍 **What is the problem this PR is trying to solve?**
Update karaf version in cxf to have compatible features. pax-http-undertow does not exists anymore in karaf 4.4.3, need to be replaced.

🚀 **What is the chosen solution to this problem?**
update features.xml

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR