### PR TITLE
fix(TPRUN-6050) guava .createTempDir() vulnerability | CVE-2020-8908

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -329,7 +329,7 @@
         <!-- <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${cxf.reflections.bundle.version}</bundle> -->
         <bundle start-level="30" dependency="true">wrap:mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${cxf.reflections.bundle.version}$overwrite=merge&amp;Import-Package=com.google.common.*;version="[20.0,32)";resolution:=optional,*;resolution:=optional</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/failureaccess/${cxf.swagger2.guava.failureaccess.version}</bundle>
-        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.swagger2.guava.version}</bundle>
+        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-annotations/${cxf.swagger2.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-models/${cxf.swagger2.version}</bundle>
         <bundle start-level="35" dependency="true">wrap:mvn:io.swagger/swagger-core/${cxf.swagger2.version}</bundle>

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -70,7 +70,7 @@
         <bundle start-level="25" dependency="true">mvn:commons-codec/commons-codec/${cxf.commons-codec.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:org.apache.santuario/xmlsec/${cxf.xmlsec.bundle.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/failureaccess/1.0.1</bundle>
-        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.version}</bundle>
+        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.tesb.version}</bundle>
         <!-- <bundle start-level="25" dependency='true'>mvn:io.dropwizard.metrics/metrics-core/${cxf.dropwizard3.version}</bundle> -->
         <bundle start-level="25" dependency='true'>mvn:io.dropwizard.metrics/metrics-core/${cxf.dropwizard4.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.opensaml/${cxf.opensaml.osgi.version}</bundle>
@@ -329,7 +329,7 @@
         <!-- <bundle start-level="30" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${cxf.reflections.bundle.version}</bundle> -->
         <bundle start-level="30" dependency="true">wrap:mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${cxf.reflections.bundle.version}$overwrite=merge&amp;Import-Package=com.google.common.*;version="[20.0,32)";resolution:=optional,*;resolution:=optional</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/failureaccess/${cxf.swagger2.guava.failureaccess.version}</bundle>
-        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.version}</bundle>
+        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.tesb.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-annotations/${cxf.swagger2.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:io.swagger/swagger-models/${cxf.swagger2.version}</bundle>
         <bundle start-level="35" dependency="true">wrap:mvn:io.swagger/swagger-core/${cxf.swagger2.version}</bundle>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,7 +119,7 @@
         <cxf.geronimo.openapi.version>1.0.15</cxf.geronimo.openapi.version>
         <cxf.glassfish.el.version>3.0.1-b11</cxf.glassfish.el.version>
         <cxf.glassfish.json.version>1.1.4</cxf.glassfish.json.version>
-        <cxf.guava.version>30.1-jre</cxf.guava.version>
+        <cxf.guava.version>32.0.1-jre</cxf.guava.version>
         <cxf.hamcrest.version>2.2</cxf.hamcrest.version>
         <cxf.hazelcast.version>3.12.13</cxf.hazelcast.version>
         <cxf.hibernate.em.version>5.6.14.Final</cxf.hibernate.em.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2054,6 +2054,12 @@
                 <artifactId>ehcache</artifactId>
                 <version>${cxf.ehcache3.version}</version>
             </dependency>
+            <!-- Override guava dependency for a security fix -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <profiles>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -214,6 +214,7 @@
         <cxf.swagger.v3.version>2.1.6</cxf.swagger.v3.version>
         <cxf.swagger2.version>1.6.8</cxf.swagger2.version>
         <cxf.swagger2.guava.failureaccess.version>1.0.1</cxf.swagger2.guava.failureaccess.version>
+        <cxf.swagger2.guava.version>31.0.1-jre</cxf.swagger2.guava.version>
         <cxf.tika.version>1.28.5</cxf.tika.version>
         <cxf.tomcat.version>9.0.70</cxf.tomcat.version>
         <cxf.tomitribe.http.signature.version>1.8</cxf.tomitribe.http.signature.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,7 +119,7 @@
         <cxf.geronimo.openapi.version>1.0.15</cxf.geronimo.openapi.version>
         <cxf.glassfish.el.version>3.0.1-b11</cxf.glassfish.el.version>
         <cxf.glassfish.json.version>1.1.4</cxf.glassfish.json.version>
-        <cxf.guava.version>32.0.1-jre</cxf.guava.version>
+        <cxf.guava.version>30.1-jre</cxf.guava.version>
         <cxf.hamcrest.version>2.2</cxf.hamcrest.version>
         <cxf.hazelcast.version>3.12.13</cxf.hazelcast.version>
         <cxf.hibernate.em.version>5.6.14.Final</cxf.hibernate.em.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2058,7 +2058,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
+                <version>${cxf.guava.tesb.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -213,7 +213,6 @@
         <cxf.swagger.ui.version>4.15.5</cxf.swagger.ui.version>
         <cxf.swagger.v3.version>2.1.6</cxf.swagger.v3.version>
         <cxf.swagger2.version>1.6.8</cxf.swagger2.version>
-        <cxf.swagger2.guava.version>31.0.1-jre</cxf.swagger2.guava.version>
         <cxf.swagger2.guava.failureaccess.version>1.0.1</cxf.swagger2.guava.failureaccess.version>
         <cxf.tika.version>1.28.5</cxf.tika.version>
         <cxf.tomcat.version>9.0.70</cxf.tomcat.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -213,8 +213,8 @@
         <cxf.swagger.ui.version>4.15.5</cxf.swagger.ui.version>
         <cxf.swagger.v3.version>2.1.6</cxf.swagger.v3.version>
         <cxf.swagger2.version>1.6.8</cxf.swagger2.version>
-        <cxf.swagger2.guava.failureaccess.version>1.0.1</cxf.swagger2.guava.failureaccess.version>
         <cxf.swagger2.guava.version>31.0.1-jre</cxf.swagger2.guava.version>
+        <cxf.swagger2.guava.failureaccess.version>1.0.1</cxf.swagger2.guava.failureaccess.version>
         <cxf.tika.version>1.28.5</cxf.tika.version>
         <cxf.tomcat.version>9.0.70</cxf.tomcat.version>
         <cxf.tomitribe.http.signature.version>1.8</cxf.tomitribe.http.signature.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <cxf-bundle-compatible.tesb.version>3.4.10.tesb1</cxf-bundle-compatible.tesb.version>
         <cxf.jakarta.mail.tesb.version>1.6.6</cxf.jakarta.mail.tesb.version>
         <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
+        <cxf.guava.tesb.version>32.0.1-jre</cxf.guava.tesb.version>
         <cxf.ehcache3.tesb.version>3.10.8</cxf.ehcache3.tesb.version>
         <cxf.netty.tesb.version>4.1.86.Final</cxf.netty.tesb.version>
         <cxf.jettison.tesb.version>1.5.4</cxf.jettison.tesb.version>
@@ -455,6 +456,7 @@
                             <cxf-bundle-compatible.tesb.version>${cxf-bundle-compatible.tesb.version}</cxf-bundle-compatible.tesb.version>
                             <cxf.jakarta.mail.tesb.version>${cxf.jakarta.mail.tesb.version}</cxf.jakarta.mail.tesb.version>
                             <cxf.geronimo.jms2.tesb.version>${cxf.geronimo.jms2.tesb.version}</cxf.geronimo.jms2.tesb.version>
+                            <cxf.guava.tesb.version>${cxf.guava.tesb.version}</cxf.guava.tesb.version>
                             <cxf.ehcache3.tesb.version>${cxf.ehcache3.tesb.version}</cxf.ehcache3.tesb.version>
                             <cxf.netty.tesb.version>${cxf.netty.tesb.version}</cxf.netty.tesb.version>
                             <cxf.jettison.tesb.version>${cxf.jettison.tesb.version}</cxf.jettison.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.10</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.10.tesb2</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.10.tesb3</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.10.tesb1</cxf-services-xkms.features.tesb.version>
         <cxf-core.tesb.version>3.4.10.tesb1</cxf-core.tesb.version>
         <cxf-services-wsn-core.tesb.version>3.4.10.tesb1</cxf-services-wsn-core.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [TPRUN-6050](https://jira.talendforge.org/browse/TPRUN-6050)
- Fix in release notes: https://github.com/google/guava/releases

🔍 **What is the problem this PR is trying to solve?**
In Guava 30, the method was declared as deprecated without addressing the vulnerability (it was only rectified in the latest release, 32.0.1-jre). Currently, some databases still identify Guava 30 as a CVE.

🚀 **What is the chosen solution to this problem?**
Bump-up guava version

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR