### PR TITLE
fix(TPRUN-6049) guava .createTempDir() vulnerability | CVE-2020-8908

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -70,7 +70,7 @@
         <bundle start-level="25" dependency="true">mvn:commons-codec/commons-codec/${cxf.commons-codec.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:org.apache.santuario/xmlsec/${cxf.xmlsec.bundle.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/failureaccess/1.0.1</bundle>
-        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.version}</bundle>
+        <bundle start-level="25" dependency="true">mvn:com.google.guava/guava/${cxf.guava.tesb.version}</bundle>
         <!-- <bundle start-level="25" dependency='true'>mvn:io.dropwizard.metrics/metrics-core/${cxf.dropwizard3.version}</bundle> -->
         <bundle start-level="25" dependency='true'>mvn:io.dropwizard.metrics/metrics-core/${cxf.dropwizard4.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.opensaml/${cxf.opensaml.osgi.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.10</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.10.20230322</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.10.20230623</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.10.20230322</cxf-services-xkms.features.tesb.version>
         <cxf-core.tesb.version>3.4.10.20230322</cxf-core.tesb.version>
         <cxf-services-wsn-core.tesb.version>3.4.10.20230322</cxf-services-wsn-core.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <cxf-bundle-compatible.tesb.version>3.4.10.20230322</cxf-bundle-compatible.tesb.version>
         <cxf.jakarta.mail.tesb.version>1.6.6</cxf.jakarta.mail.tesb.version>
         <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
+        <cxf.guava.tesb.version>32.0.1-jre</cxf.guava.tesb.version>
         <cxf.netty.tesb.version>4.1.86.Final</cxf.netty.tesb.version>
         <cxf.jettison.tesb.version>1.5.4</cxf.jettison.tesb.version>
 
@@ -454,6 +455,7 @@
                             <cxf-bundle-compatible.tesb.version>${cxf-bundle-compatible.tesb.version}</cxf-bundle-compatible.tesb.version>
                             <cxf.jakarta.mail.tesb.version>${cxf.jakarta.mail.tesb.version}</cxf.jakarta.mail.tesb.version>
                             <cxf.geronimo.jms2.tesb.version>${cxf.geronimo.jms2.tesb.version}</cxf.geronimo.jms2.tesb.version>
+                            <cxf.guava.tesb.version>${cxf.guava.tesb.version}</cxf.guava.tesb.version>
                             <cxf.netty.tesb.version>${cxf.netty.tesb.version}</cxf.netty.tesb.version>
                             <cxf.jettison.tesb.version>${cxf.jettison.tesb.version}</cxf.jettison.tesb.version>
                         </properties>


### PR DESCRIPTION
🏁 **Context**
- [TPRUN-6049](https://jira.talendforge.org/browse/TPRUN-6049)
- Fix in release notes: https://github.com/google/guava/releases

🔍 **What is the problem this PR is trying to solve?**
In Guava 30, the .createTempDir() method was declared as deprecated without addressing the vulnerability (it was only rectified in the latest release, 32.0.1-jre). Currently, some databases still identify Guava 30 as a CVE.

🚀 **What is the chosen solution to this problem?**
Bump-up guava version

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR