### PR TITLE
fix(TPRUN-3553): in the constructor of LoggingFeature, set the config…

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features'
+        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features,org.apache.cxf:cxf-rt-features-logging'
 )

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
@@ -26,6 +26,7 @@ import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.ext.logging.event.LogEventSender;
 import org.apache.cxf.ext.logging.event.PrettyLoggingFilter;
+import org.apache.cxf.ext.logging.osgi.Activator;
 import org.apache.cxf.ext.logging.slf4j.Slf4jEventSender;
 import org.apache.cxf.ext.logging.slf4j.Slf4jVerboseEventSender;
 import org.apache.cxf.feature.AbstractPortableFeature;
@@ -52,6 +53,7 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 public class LoggingFeature extends DelegatingFeature<LoggingFeature.Portable> {
     public LoggingFeature() {
         super(new Portable());
+        Activator.configureLoggingFeature(this);
     }
 
     public void setLimit(int limit) {

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/osgi/Activator.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/osgi/Activator.java
@@ -18,20 +18,21 @@
  */
 package org.apache.cxf.ext.logging.osgi;
 
-import java.util.Arrays;
-import java.util.Dictionary;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Set;
+import java.io.IOException;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.cxf.ext.logging.LoggingFeature;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.Feature;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
@@ -52,8 +53,25 @@ public class Activator implements BundleActivator {
     public void stop(BundleContext context) throws Exception {
 
     }
+    public static void configureLoggingFeature(LoggingFeature loggingFeature) {
+        Bundle bundle = FrameworkUtil.getBundle(Activator.class);
+        if (bundle != null) {
+            try {
+                BundleContext bundleContext = bundle.getBundleContext();
+                ConfigurationAdmin configAdmin = (ConfigurationAdmin) bundleContext.
+                        getService(bundleContext.getServiceReference(ConfigurationAdmin.class.getName()));
+                Configuration configF = configAdmin.getConfiguration(CONFIG_PID);
+                if (configF != null) {
+                    Dictionary<String, Object> config = configF.getProperties();
+                    updated(config, loggingFeature);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
-    private static final class ConfigUpdater implements ManagedService {
+    public static final class ConfigUpdater implements ManagedService {
         private BundleContext bundleContext;
         private ServiceRegistration<?> serviceReg;
         private ServiceRegistration<?> intentReg;
@@ -64,49 +82,9 @@ public class Activator implements BundleActivator {
             this.bundleContext = bundleContext;
         }
 
-        @SuppressWarnings("rawtypes")
         @Override
         public void updated(Dictionary config) throws ConfigurationException {
-            boolean enabled = Boolean.valueOf(getValue(config, "enabled", "false"));
-            LOG.info("CXF message logging feature " + (enabled ? "enabled" : "disabled"));
-            Integer limit = Integer.valueOf(getValue(config, "limit", "65536"));
-            Boolean pretty = Boolean.valueOf(getValue(config, "pretty", "false"));
-            Boolean verbose = Boolean.valueOf(getValue(config, "verbose", "true"));
-            Long inMemThreshold = Long.valueOf(getValue(config, "inMemThresHold", "-1"));
-            Boolean logMultipart = Boolean.valueOf(getValue(config, "logMultipart", "true"));
-            Boolean logBinary = Boolean.valueOf(getValue(config, "logBinary", "false"));
-            Set<String> sensitiveElementNames = getTrimmedSet(config, "sensitiveElementNames");
-            Set<String> sensitiveProtocolHeaderNames = getTrimmedSet(config, "sensitiveProtocolHeaderNames");
-            
-            if (limit != null) {
-                logging.setLimit(limit);
-            }
-            if (inMemThreshold != null) {
-                logging.setInMemThreshold(inMemThreshold);
-            }
-            if (pretty != null) {
-                logging.setPrettyLogging(pretty);
-            }
-            
-            if (verbose != null) {
-                logging.setVerbose(verbose);
-            }
-            if (logMultipart != null) {                       
-                logging.setLogMultipart(logMultipart);
-            }
-            if (logBinary != null) {
-                logging.setLogBinary(logBinary);
-            }
-            
-            logging.setSensitiveElementNames(sensitiveElementNames);
-            logging.setSensitiveProtocolHeaderNames(sensitiveProtocolHeaderNames);
-
-            if (intentReg == null) {
-                Dictionary<String, Object> properties = new Hashtable<>();
-                properties.put("org.apache.cxf.dosgi.IntentName", "logging");
-                bundleContext.registerService(AbstractFeature.class.getName(), logging, properties);
-            }
-
+            boolean enabled = Activator.updated(config, logging);
             if (enabled) {
                 if (serviceReg == null) {
                     Dictionary<String, Object> properties = new Hashtable<>();
@@ -119,26 +97,70 @@ public class Activator implements BundleActivator {
                     serviceReg = null;
                 }
             }
-        }
-
-        @SuppressWarnings("rawtypes")
-        private Set<String> getTrimmedSet(Dictionary config, String propertyKey) {
-            return new HashSet<>(
-                    Arrays.stream(String.valueOf(getValue(config, propertyKey, "")).split(","))
-                            .map(String::trim)
-                            .filter(s -> !s.isEmpty())
-                            .collect(Collectors.toSet()));
-        }
-
-        @SuppressWarnings("rawtypes")
-        private String getValue(Dictionary config, String key, String defaultValue) {
-            if (config == null) {
-                return defaultValue;
+            if (intentReg == null) {
+                Dictionary<String, Object> properties = new Hashtable<>();
+                properties.put("org.apache.cxf.dosgi.IntentName", "logging");
+                bundleContext.registerService(AbstractFeature.class.getName(), logging, properties);
             }
-            String value = (String)config.get(key);
-            return value != null ? value : defaultValue;
         }
 
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Set<String> getTrimmedSet(Dictionary config, String propertyKey) {
+        return new HashSet<>(
+                Arrays.stream(String.valueOf(getValue(config, propertyKey, "")).split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toSet()));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static String getValue(Dictionary config, String key, String defaultValue) {
+        if (config == null) {
+            return defaultValue;
+        }
+        String value = (String)config.get(key);
+        return value != null ? value : defaultValue;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static boolean updated(Dictionary config, LoggingFeature logging) {
+        boolean enabled = Boolean.valueOf(getValue(config, "enabled", "false"));
+        LOG.info("CXF message logging feature " + (enabled ? "enabled" : "disabled"));
+        Integer limit = Integer.valueOf(getValue(config, "limit", "65536"));
+        Boolean pretty = Boolean.valueOf(getValue(config, "pretty", "false"));
+        Boolean verbose = Boolean.valueOf(getValue(config, "verbose", "true"));
+        Long inMemThreshold = Long.valueOf(getValue(config, "inMemThresHold", "-1"));
+        Boolean logMultipart = Boolean.valueOf(getValue(config, "logMultipart", "true"));
+        Boolean logBinary = Boolean.valueOf(getValue(config, "logBinary", "false"));
+        Set<String> sensitiveElementNames = getTrimmedSet(config, "sensitiveElementNames");
+        Set<String> sensitiveProtocolHeaderNames = getTrimmedSet(config, "sensitiveProtocolHeaderNames");
+
+        if (limit != null) {
+            logging.setLimit(limit);
+        }
+        if (inMemThreshold != null) {
+            logging.setInMemThreshold(inMemThreshold);
+        }
+        if (pretty != null) {
+            logging.setPrettyLogging(pretty);
+        }
+
+        if (verbose != null) {
+            logging.setVerbose(verbose);
+        }
+        if (logMultipart != null) {
+            logging.setLogMultipart(logMultipart);
+        }
+        if (logBinary != null) {
+            logging.setLogBinary(logBinary);
+        }
+
+        logging.setSensitiveElementNames(sensitiveElementNames);
+        logging.setSensitiveProtocolHeaderNames(sensitiveProtocolHeaderNames);
+
+        return enabled;
     }
 
 }


### PR DESCRIPTION
…uration from the bundle if it exists🏁 **Context**
- [TPRUN-3553](https://jira.talendforge.org/browse/TPRUN-3553)

🔍 **What is the problem this PR is trying to solve?**
Authorization header is logged

🚀 **What is the chosen solution to this problem?**
Even is LoggingFeature is not enable, read the configuration to set the sensitiveHeaders, so that the password are not logged by default

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR