### PR TITLE
fix(TPRUN-3353): Logging*Interceptor should read the configuration

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features'
+        MVN_MODULES: 'org.apache.cxf:cxf-core,org.apache.cxf.services.wsn:cxf-services-wsn-core,org.apache.cxf.karaf:apache-cxf,org.apache.cxf.services.xkms:cxf-services-xkms-features,org.apache.cxf:cxf-rt-features-logging'
 )

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -369,7 +369,7 @@
     </feature>
     <feature name="cxf-features-logging" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-core</feature>
-        <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-features-logging/${upstream.version}</bundle>
+        <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-features-logging/${cxf-logging.tesb.version}</bundle>
     </feature>
     <feature name="cxf-features-throttling" version="${upstream.version}">
         <feature version="${upstream.version}">cxf-core</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,10 @@
     </issueManagement>
     <properties>
         <upstream.version>3.4.10</upstream.version>
-        <apache-cxf.features.tesb.version>3.4.10.tesb3</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.4.10.tesb4</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>3.4.10.tesb1</cxf-services-xkms.features.tesb.version>
         <cxf-core.tesb.version>3.4.10.tesb1</cxf-core.tesb.version>
+        <cxf-logging.tesb.version>3.4.10.tesb1</cxf-logging.tesb.version>
         <cxf-services-wsn-core.tesb.version>3.4.10.tesb1</cxf-services-wsn-core.tesb.version>
         <cxf-bundle-compatible.tesb.version>3.4.10.tesb1</cxf-bundle-compatible.tesb.version>
         <cxf.jakarta.mail.tesb.version>1.6.6</cxf.jakarta.mail.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,7 @@
                             <apache-cxf.features.tesb.version>${apache-cxf.features.tesb.version}</apache-cxf.features.tesb.version>
                             <cxf-services-xkms.features.tesb.version>${cxf-services-xkms.features.tesb.version}</cxf-services-xkms.features.tesb.version>
                             <cxf-core.tesb.version>${cxf-core.tesb.version}</cxf-core.tesb.version>
+                            <cxf-logging.tesb.version>${cxf-logging.tesb.version}</cxf-logging.tesb.version>
                             <cxf-services-wsn-core.tesb.version>${cxf-services-wsn-core.tesb.version}</cxf-services-wsn-core.tesb.version>
                             <cxf-bundle-compatible.tesb.version>${cxf-bundle-compatible.tesb.version}</cxf-bundle-compatible.tesb.version>
                             <cxf.jakarta.mail.tesb.version>${cxf.jakarta.mail.tesb.version}</cxf.jakarta.mail.tesb.version>

--- a/rt/features/logging/pom.xml
+++ b/rt/features/logging/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <artifactId>cxf-rt-features-logging</artifactId>
     <packaging>bundle</packaging>
-    
+    <version>${revision}</version>
     <properties>
         <cxf.module.name>org.apache.cxf.logging</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.ext.logging.osgi.Activator</cxf.bundle.activator>

--- a/rt/features/logging/pom.xml
+++ b/rt/features/logging/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <cxf.module.name>org.apache.cxf.logging</cxf.module.name>
         <cxf.bundle.activator>org.apache.cxf.ext.logging.osgi.Activator</cxf.bundle.activator>
+        <revision>${cxf-logging.tesb.version}</revision>
     </properties>
 
     <name>Apache CXF Advanced Logging Feature</name>

--- a/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
+++ b/rt/features/logging/src/main/java/org/apache/cxf/ext/logging/LoggingFeature.java
@@ -26,6 +26,7 @@ import org.apache.cxf.annotations.Provider.Type;
 import org.apache.cxf.common.injection.NoJSR250Annotations;
 import org.apache.cxf.ext.logging.event.LogEventSender;
 import org.apache.cxf.ext.logging.event.PrettyLoggingFilter;
+import org.apache.cxf.ext.logging.osgi.Activator;
 import org.apache.cxf.ext.logging.slf4j.Slf4jEventSender;
 import org.apache.cxf.ext.logging.slf4j.Slf4jVerboseEventSender;
 import org.apache.cxf.feature.AbstractPortableFeature;
@@ -52,6 +53,7 @@ import org.apache.cxf.interceptor.InterceptorProvider;
 public class LoggingFeature extends DelegatingFeature<LoggingFeature.Portable> {
     public LoggingFeature() {
         super(new Portable());
+        Activator.configureLoggingFeature(this);
     }
 
     public void setLimit(int limit) {


### PR DESCRIPTION
🏁 **Context**
- [TPRUN-3553](https://jira.talendforge.org/browse/TPRUN-3553)

🔍 **What is the problem this PR is trying to solve?**
Authorization header is logged

🚀 **What is the chosen solution to this problem?**
Even is LoggingFeature is not enable, read the configuration to set the sensitiveHeaders, so that the password are not logged by default

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR