### PR TITLE
TPRUN-8496 fix staxex bundle resolution.

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -61,7 +61,7 @@
         <!-- <bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-json/${cxf.abdera.version}</bundle> -->
     </feature>
     <feature name="saaj-impl" version="${cxf.saaj-impl.version}">
-        <bundle start-level="25">mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}</bundle>
+        <bundle start-level="25">wrap:mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}$overwrite=merge&amp;Import--Package=org.jvnet.staxex;version="[1.8,2.0)",javax.xml.bind.attachment;resolution:=optional,*</bundle>
         <bundle start-level="25">mvn:com.sun.xml.messaging.saaj/saaj-impl/${cxf.saaj-impl.version}</bundle>
     </feature>
     <feature name="wss4j" version="${cxf.wss4j.version}">

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.5.9</upstream.version>
-        <apache-cxf.features.tesb.version>3.5.9.20240725</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.5.9.20240920</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>${apache-cxf.features.tesb.version}</cxf-services-xkms.features.tesb.version>
         <cxf-core.tesb.version>3.5.9.20240725</cxf-core.tesb.version>
         <cxf-rt-frontend-jaxrs.tesb.version>3.5.9.20240725</cxf-rt-frontend-jaxrs.tesb.version>


### PR DESCRIPTION
The "staxex" bundle should not re-import "org.jvnet.staxex" in version 2.0 or higher.