### PR TITLE
DPE-571 Security updates.

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -61,7 +61,7 @@
         <!-- <bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-json/${cxf.abdera.version}</bundle> -->
     </feature>
     <feature name="saaj-impl" version="${cxf.saaj-impl.version}">
-        <bundle start-level="25">mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}</bundle>
+        <bundle start-level="25">wrap:mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}$overwrite=merge&amp;Import--Package=org.jvnet.staxex;version="[1.8,2.0)",javax.xml.bind.attachment;resolution:=optional,*</bundle>
         <bundle start-level="25">mvn:com.sun.xml.messaging.saaj/saaj-impl/${cxf.saaj-impl.version}</bundle>
     </feature>
     <feature name="wss4j" version="${cxf.wss4j.version}">

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -61,7 +61,7 @@
         <!-- <bundle start-level='35'>mvn:org.apache.abdera/abdera-extensions-json/${cxf.abdera.version}</bundle> -->
     </feature>
     <feature name="saaj-impl" version="${cxf.saaj-impl.version}">
-        <bundle start-level="25">wrap:mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}$overwrite=merge&amp;Import--Package=org.jvnet.staxex;version="[1.8,2.0)",javax.xml.bind.attachment;resolution:=optional,*</bundle>
+        <bundle start-level="25">wrap:mvn:org.jvnet.staxex/stax-ex/${cxf.stax-ex.version}$overwrite=merge&amp;Import-Package=org.jvnet.staxex;version="[1.8,2.0)",javax.xml.bind.attachment;resolution:=optional,*</bundle>
         <bundle start-level="25">mvn:com.sun.xml.messaging.saaj/saaj-impl/${cxf.saaj-impl.version}</bundle>
     </feature>
     <feature name="wss4j" version="${cxf.wss4j.version}">

--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -200,15 +200,15 @@
         <bundle start-level="40">mvn:org.bouncycastle/bcutil-jdk18on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:org.bouncycastle/bctls-jdk18on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-tcnative-classes/${cxf.netty.tcnative.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec-http2/${cxf.netty.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec-http2/${cxf.netty.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-netty-client/${upstream.version}</bundle>
     </feature>
     <feature name="cxf-http-netty-server" version="${upstream.version}">
@@ -217,14 +217,14 @@
         <bundle start-level="40">mvn:org.bouncycastle/bcutil-jdk18on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:org.bouncycastle/bctls-jdk18on/${cxf.bcprov.version}</bundle>
         <bundle start-level="40">mvn:io.netty/netty-tcnative-classes/${cxf.netty.tcnative.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.version}</bundle>
-        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-handler/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-buffer/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-transport/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-resolver/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec/${cxf.netty.tesb.version}</bundle>
+        <bundle start-level="40">mvn:io.netty/netty-codec-http/${cxf.netty.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-netty-server/${upstream.version}</bundle>
         <capability>
             cxf.http.provider;name=netty
@@ -338,7 +338,7 @@
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-service-description-swagger/${upstream.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${cxf.jackson.tesb.version}</bundle>
         <bundle start-level="10" dependency="true">mvn:jakarta.validation/jakarta.validation-api/${cxf.validation.api.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.tesb.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.javassist/javassist/${cxf.javassist.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.reflections/reflections/${cxf.reflections.version}</bundle>
         <bundle start-level="25" dependency="true">mvn:com.google.guava/failureaccess/${cxf.swagger2.guava.failureaccess.version}</bundle>
@@ -357,7 +357,7 @@
         <bundle start-level="35" dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${cxf.jackson.tesb.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:${cxf.servlet-api.group}/${cxf.servlet-api.artifact}/${cxf.servlet-api.version}</bundle>
         <bundle start-level="10" dependency="true">mvn:jakarta.validation/jakarta.validation-api/${cxf.validation.api.version}</bundle>
-        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.tesb.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:io.github.classgraph/classgraph/${cxf.classgraph.tesb.version}</bundle>
         <bundle start-level="30" dependency="true">mvn:org.javassist/javassist/${cxf.javassist.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:io.swagger.core.v3/swagger-annotations/${cxf.swagger.v3.version}</bundle>
@@ -422,20 +422,20 @@
     </feature>
     <feature name="cxf-transports-websocket-client" version="${upstream.version}">
         <feature version="${cxf.tesb.version-range}">cxf-http</feature>
-        <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client/${cxf.ahc.version}</bundle>
-        <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client-netty-utils/${cxf.ahc.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-common/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-handler/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-buffer/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-resolver/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-transport-native-kqueue/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${cxf.netty.version}</bundle>
-        <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${cxf.netty.version}</bundle>
+        <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client/${cxf.ahc.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.asynchttpclient/async-http-client-netty-utils/${cxf.ahc.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-common/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-handler/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-buffer/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-resolver/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-http/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-transport-native-kqueue/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${cxf.netty.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${cxf.netty.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${cxf.reactivestreams.version}</bundle>
         <bundle dependency='true'>mvn:com.typesafe.netty/netty-reactive-streams/2.0.4</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-websocket/${upstream.version}</bundle>
@@ -469,7 +469,7 @@
     </feature>
     <feature name="cxf-xjc-runtime" version="${upstream.version}">
         <feature version="${cxf.tesb.version-range}">cxf-jaxb</feature>
-        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf.xjc-utils/cxf-xjc-runtime/${cxf.xjc-utils.version}</bundle>
     </feature>
     <feature name="cxf-tools" version="${upstream.version}">
@@ -481,9 +481,9 @@
         <feature version="${cxf.tesb.version-range}">cxf-jaxrs</feature>
         <feature version="${cxf.tesb.version-range}">cxf-jaxws</feature>
         <feature version="${cxf.tesb.version-range}">cxf-javascript</feature>
-        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.version}</bundle>
+        <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-lang3/${cxf.commons-lang3.tesb.version}</bundle>
         <bundle start-level="35" dependency="true">mvn:org.apache.commons/commons-text/${cxf.commons-text.version}</bundle>
-        <bundle dependency="true">mvn:org.apache.velocity/velocity-engine-core/${cxf.velocity.version}</bundle>
+        <bundle dependency="true">mvn:org.apache.velocity/velocity-engine-core/${cxf.velocity.tesb.version}</bundle>
         <bundle>mvn:org.apache.cxf/cxf-tools-common/${upstream.version}</bundle>
         <bundle>mvn:org.apache.cxf/cxf-tools-java2ws/${upstream.version}</bundle>
         <bundle>mvn:org.apache.cxf/cxf-tools-misctools/${upstream.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.5.9</upstream.version>
-        <apache-cxf.features.tesb.version>3.5.9.20240725</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.5.9.20250110</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>${apache-cxf.features.tesb.version}</cxf-services-xkms.features.tesb.version>
         <cxf-core.tesb.version>3.5.9.20240725</cxf-core.tesb.version>
         <cxf-rt-frontend-jaxrs.tesb.version>3.5.9.20240725</cxf-rt-frontend-jaxrs.tesb.version>
@@ -53,8 +53,10 @@
         <cxf.geronimo.jms2.tesb.version>1.0-alpha-2</cxf.geronimo.jms2.tesb.version>
         <cxf.geronimo.jms2.bundle.override.tesb.version>1.0.0.tp20240209</cxf.geronimo.jms2.bundle.override.tesb.version>
         <!-- <cxf.aries.fly.tesb.version>1.2</cxf.aries.fly.tesb.version> -->
-        <!-- <cxf.netty.tesb.version>4.1.111.Final</cxf.netty.tesb.version> -->
+        <cxf.netty.tesb.version>4.1.115.Final</cxf.netty.tesb.version>
         <!-- <cxf.commons-io.tesb.version>2.16.1</cxf.commons-io.tesb.version> -->
+        <cxf.commons-lang3.tesb.version>3.17.0</cxf.commons-lang3.tesb.version>
+        <cxf.ahc.tesb.version>2.12.4</cxf.ahc.tesb.version>
         <cxf.jackson.tesb.version>2.16.2</cxf.jackson.tesb.version>
         <cxf.jackson.databind.tesb.version>${cxf.jackson.tesb.version}</cxf.jackson.databind.tesb.version>
         <cxf.jackson.dataformat.yaml.tesb.version>2.14.3</cxf.jackson.dataformat.yaml.tesb.version>
@@ -72,9 +74,10 @@
         <cxf.james.mime4j.tesb.version>0.8.11</cxf.james.mime4j.tesb.version>
         <cxf.jdom1.bundle.tesb.version>1.1_4</cxf.jdom1.bundle.tesb.version>
         <cxf.joda.time.tesb.version>2.11.1</cxf.joda.time.tesb.version>
-        <cxf.mina.tesb.version>2.1.8</cxf.mina.tesb.version>
+        <cxf.mina.tesb.version>2.1.10</cxf.mina.tesb.version>
         <!-- <cxf.xmlsec.bundle.tesb.version>2.3.4</cxf.xmlsec.bundle.tesb.version> -->
         <cxf.servicemix.aspectj.tesb.version>1.9.21.1_1</cxf.servicemix.aspectj.tesb.version>
+        <cxf.velocity.tesb.version>2.4.1</cxf.velocity.tesb.version>
         <cxf.xerces.bundle.tesb.version>2.12.2.tesb1_1</cxf.xerces.bundle.tesb.version>
         <cxf.guava.tesb.version>32.1.3-jre</cxf.guava.tesb.version>
         <cxf.swagger2.guava.tesb.version>${cxf.guava.tesb.version}</cxf.swagger2.guava.tesb.version>
@@ -498,8 +501,10 @@
                             <cxf.geronimo.jms2.tesb.version>${cxf.geronimo.jms2.tesb.version}</cxf.geronimo.jms2.tesb.version>
                             <cxf.geronimo.jms2.bundle.override.tesb.version>${cxf.geronimo.jms2.bundle.override.tesb.version}</cxf.geronimo.jms2.bundle.override.tesb.version>
                             <!-- <cxf.aries.fly.tesb.version>${cxf.aries.fly.tesb.version}</cxf.aries.fly.tesb.version> -->
-                            <!-- <cxf.netty.tesb.version>${cxf.netty.tesb.version}</cxf.netty.tesb.version> -->
+                            <cxf.netty.tesb.version>${cxf.netty.tesb.version}</cxf.netty.tesb.version>
                             <!-- <cxf.commons-io.tesb.version>${cxf.commons-io.tesb.version}</cxf.commons-io.tesb.version> -->
+                            <cxf.commons-lang3.tesb.version>${cxf.commons-lang3.tesb.version}</cxf.commons-lang3.tesb.version>
+                            <cxf.ahc.tesb.version>${cxf.ahc.tesb.version}</cxf.ahc.tesb.version>
                             <cxf.jackson.tesb.version>${cxf.jackson.tesb.version}</cxf.jackson.tesb.version>
                             <cxf.jackson.databind.tesb.version>${cxf.jackson.databind.tesb.version}</cxf.jackson.databind.tesb.version>
                             <cxf.jackson.dataformat.yaml.tesb.version>${cxf.jackson.dataformat.yaml.tesb.version}</cxf.jackson.dataformat.yaml.tesb.version>
@@ -520,6 +525,7 @@
                             <cxf.mina.tesb.version>${cxf.mina.tesb.version}</cxf.mina.tesb.version>
                             <!-- <cxf.xmlsec.bundle.tesb.version>${cxf.xmlsec.bundle.tesb.version}</cxf.xmlsec.bundle.tesb.version> -->
                             <cxf.servicemix.aspectj.tesb.version>${cxf.servicemix.aspectj.tesb.version}</cxf.servicemix.aspectj.tesb.version>
+                            <cxf.velocity.tesb.version>${cxf.velocity.tesb.version}</cxf.velocity.tesb.version>
                             <cxf.xerces.bundle.tesb.version>${cxf.xerces.bundle.tesb.version}</cxf.xerces.bundle.tesb.version>
                             <cxf.guava.tesb.version>${cxf.guava.tesb.version}</cxf.guava.tesb.version>
                             <cxf.swagger2.guava.tesb.version>${cxf.swagger2.guava.tesb.version}</cxf.swagger2.guava.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <!-- <cxf.commons-io.tesb.version>2.16.1</cxf.commons-io.tesb.version> -->
         <cxf.commons-lang3.tesb.version>3.17.0</cxf.commons-lang3.tesb.version>
         <cxf.ahc.tesb.version>2.12.4</cxf.ahc.tesb.version>
-        <cxf.jackson.tesb.version>2.16.2</cxf.jackson.tesb.version>
+        <cxf.jackson.tesb.version>2.17.2</cxf.jackson.tesb.version>
         <cxf.jackson.databind.tesb.version>${cxf.jackson.tesb.version}</cxf.jackson.databind.tesb.version>
         <cxf.jackson.dataformat.yaml.tesb.version>2.14.3</cxf.jackson.dataformat.yaml.tesb.version>
         <!-- <cxf.jettison.tesb.version>1.5.4</cxf.jettison.tesb.version> -->


### PR DESCRIPTION
velocity-engine-core 2.3 -> 2.4.1 - CVE-2024-47554(commons-io)
netty 4.1.111.Final -> 4.1.115.Final - CVE-2024-47535
mina 2.1.6,2.1.8 -> 2.1.10 - CVE-2024-52046
async-http-client 2.12.3 -> 2.12.4 - CVE-2024-53990