### PR TITLE
DPE-761: replace invalid bundles versions

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -326,8 +326,8 @@
         <feature version="${cxf.tesb.version-range}">cxf-core</feature>
         <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-api/${cxf.opentelemetry.version}$Bundle-SymbolicName=opentelemetry-api&amp;Bundle-Version=${cxf.opentelemetry.version}</bundle>
         <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-context/${cxf.opentelemetry.version}$Bundle-SymbolicName=opentelemetry-context&amp;Bundle-Version=${cxf.opentelemetry.version}</bundle>
-        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv/${cxf.opentelemetry.semconv.version}$Bundle-SymbolicName=opentelemetry-semconv&amp;Bundle-Version=${cxf.opentelemetry.semconv.version}</bundle>
-        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv-incubating/${cxf.opentelemetry.semconv.version}$Bundle-SymbolicName=opentelemetry-semconv-incubating&amp;Bundle-Version=${cxf.opentelemetry.semconv.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv/${cxf.opentelemetry.semconv.tesb.version}$Bundle-SymbolicName=opentelemetry-semconv&amp;Bundle-Version=${cxf.opentelemetry.semconv.bundle.tesb.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv-incubating/${cxf.opentelemetry.semconv.tesb.version}$Bundle-SymbolicName=opentelemetry-semconv-incubating&amp;Bundle-Version=${cxf.opentelemetry.semconv.bundle.tesb.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-integration-tracing-opentelemetry/${upstream.version}</bundle>
     </feature>
     <feature name="cxf-rs-description-swagger2" version="${upstream.version}">

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </issueManagement>
     <properties>
         <upstream.version>3.5.9</upstream.version>
-        <apache-cxf.features.tesb.version>3.5.9.20250110</apache-cxf.features.tesb.version>
+        <apache-cxf.features.tesb.version>3.5.9.20250213</apache-cxf.features.tesb.version>
         <cxf-services-xkms.features.tesb.version>${apache-cxf.features.tesb.version}</cxf-services-xkms.features.tesb.version>
         <cxf-core.tesb.version>3.5.9.20240725</cxf-core.tesb.version>
         <cxf-rt-frontend-jaxrs.tesb.version>3.5.9.20240725</cxf-rt-frontend-jaxrs.tesb.version>
@@ -82,6 +82,8 @@
         <cxf.guava.tesb.version>32.1.3-jre</cxf.guava.tesb.version>
         <cxf.swagger2.guava.tesb.version>${cxf.guava.tesb.version}</cxf.swagger2.guava.tesb.version>
         <cxf.guava.tesb.version-range>[32,40)</cxf.guava.tesb.version-range>
+        <cxf.opentelemetry.semconv.tesb.version>1.26.0-alpha</cxf.opentelemetry.semconv.tesb.version>
+        <cxf.opentelemetry.semconv.bundle.tesb.version>1.26.0.alpha</cxf.opentelemetry.semconv.bundle.tesb.version>
 
         <cxf.compiler.fork>false</cxf.compiler.fork>
         <cxf.build-utils.version>3.4.4</cxf.build-utils.version>
@@ -530,6 +532,8 @@
                             <cxf.guava.tesb.version>${cxf.guava.tesb.version}</cxf.guava.tesb.version>
                             <cxf.swagger2.guava.tesb.version>${cxf.swagger2.guava.tesb.version}</cxf.swagger2.guava.tesb.version>
                             <cxf.guava.tesb.version-range>${cxf.guava.tesb.version-range}</cxf.guava.tesb.version-range>
+                            <cxf.opentelemetry.semconv.tesb.version>${cxf.opentelemetry.semconv.tesb.version}</cxf.opentelemetry.semconv.tesb.version>
+                            <cxf.opentelemetry.semconv.bundle.tesb.version>${cxf.opentelemetry.semconv.bundle.tesb.version}</cxf.opentelemetry.semconv.bundle.tesb.version>
                         </properties>
                     </configuration>
                     <executions>


### PR DESCRIPTION
🏁 **Context**
- [DPE-761](https://qlik-dev.atlassian.net/browse/DPE-761)

🔍 **What is the problem this PR is trying to solve?**
`opentelemetry` feature include bundles with invalid versions

🚀 **What is the chosen solution to this problem?**
Override the `Bundle-Version` header with a valid version.

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-761]: https://qlik-dev-sandbox-345.atlassian.net/browse/DPE-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ