### PR TITLE
fix(DPE-1630): remove outdated wrap protocol for ehcache to prevent multiple classloaders

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -573,7 +573,7 @@
     <feature name="cxf-sts" version="${project.version}">
         <feature prerequisite="true">wrap</feature>
         <bundle start-level="40" dependency="true">mvn:com.hazelcast/hazelcast/${cxf.hazelcast.tesb.version}</bundle>
-        <bundle start-level="40" dependency="true">wrap:mvn:org.ehcache/ehcache/${cxf.ehcache3.version}$overwrite=merge&amp;Import-Package=javax.xml.bind*,*;resolution:=optional</bundle>
+        <bundle start-level="40" dependency="true">mvn:org.ehcache/ehcache/${cxf.ehcache3.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-rs-security-jose/${project.version}</bundle>
         <feature version="${cxf.tesb.version-range}">cxf-core</feature>
         <feature version="${cxf.tesb.version-range}">cxf-ws-security</feature>


### PR DESCRIPTION
🏁 **Context (Jira, design, ...)**
- https://qlik-dev.atlassian.net/browse/DPE-1630

🔍 **What is the problem this PR is trying to solve?**

🚀 **What is the chosen solution to this problem?**

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
