### PR TITLE
fix(DPE-1511): Add annotation to prioritize cxf writer over fasterxml

### DIFF
--- a/rt/rs/extensions/providers/src/main/java/org/apache/cxf/jaxrs/provider/json/JSONProvider.java
+++ b/rt/rs/extensions/providers/src/main/java/org/apache/cxf/jaxrs/provider/json/JSONProvider.java
@@ -81,7 +81,7 @@ import org.codehaus.jettison.mapped.SimpleConverter;
 import org.codehaus.jettison.mapped.TypeConverter;
 import org.codehaus.jettison.util.StringIndenter;
 
-@Produces({"application/json", "application/*+json" })
+@Produces({"application/json", "application/*+json", "text/json" })
 @Consumes({"application/json", "application/*+json" })
 @Provider
 public class JSONProvider<T> extends AbstractJAXBProvider<T>  {


### PR DESCRIPTION
🏁 **Context**
- [DPE-1511](https://qlik-dev.atlassian.net/browse/DPE-1511)

🔍 **What is the problem this PR is trying to solve?**
since [Fix #30: add explicit mime type for `@Produces` (#31) · FasterXML/jackson-jakarta-rs-providers@ae90d2a](https://github.com/FasterXML/jackson-jakarta-rs-providers/commit/ae90d2aba29b62da55fbce230048034ade65fac4)   annotations have been added to the classes, 
in org.apache.cxf.jaxrs.provider.ProviderFactory.MessageBodyWriterComparator ,  the array of writers is sorted, and the one with the more annotations are being given priority

so in karaf, since 2.18.3 the com.fasterxml.jackson.jakarta.rs.json.JacksonXmlBindJsonProvider writer is used instead of the org.apache.cxf.jaxrs.provider.json.JSONProvider  .
in the microservice mode, the version 2.17 of jackson is still in use so it doesn’t behave in the same way.

🚀 **What is the chosen solution to this problem?**
Add the "text/json"  which is a non standard mime type, but listed in faster xml so that cxf has more annotations than the fasterxml writer

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-1511]: https://qlik-dev.atlassian.net/browse/DPE-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ