### PR TITLE
fix(DPE-1805): re-add CXF Jetty blueprint xmlns handler in camel-karaf

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -224,7 +224,12 @@
     <feature name="cxf-http-jetty" version="${project.version}">
         <feature version="${cxf.tesb.version-range}">cxf-http</feature>
         <feature version="[12,13)">pax-web-jetty</feature>
-        <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-jetty/${project.version}</bundle>
+        <!-- The feature below includes org.apache.camel.karaf/camel-cxf-transport-jetty,
+            which provides the Blueprint xmlns handler for CXF Jetty plus the CXF Jetty transport packages
+        -->
+        <feature version="[4.8,4.9)">camel-cxf-jetty</feature>
+        <!-- The bundle below provides the Spring xmlns handler for CXF Jetty plus the CXF Jetty transport packages -->
+        <!-- <bundle start-level="40">mvn:org.apache.cxf/cxf-rt-transports-http-jetty/${project.version}</bundle> -->
         <capability>
             cxf.http.provider;name=jetty
         </capability>


### PR DESCRIPTION
🏁 **Context**
- [DPE-1805](https://qlik-dev.atlassian.net/browse/DPE-1805)

🔍 **What is the problem this PR is trying to solve?**
Blueprint files cannot properly use the CXF Jetty xmlns because there is no handler. Currently, installed handler is for Spring.

🚀 **What is the chosen solution to this problem?**
Port a recent commit from the official `camel-karaf` repo where the CXF Jetty blueprint xmlns handler was re-added.
Set the Blueprint handler for CXF Jetty xmlns as the default one.

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-1805]: https://qlik-dev.atlassian.net/browse/DPE-1805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ