### PR TITLE
DPE-3094 Security updates.

### DIFF
--- a/osgi/karaf/features/src/main/resources/features.xml
+++ b/osgi/karaf/features/src/main/resources/features.xml
@@ -24,20 +24,6 @@
         <bundle start-level="10">mvn:jakarta.servlet/jakarta.servlet-api/6.1.0</bundle>
         <bundle start-level="10" start="false">mvn:org.ops4j.pax.web/pax-web-compatibility-servlet/11.0.1</bundle>
     </feature>
-    <!-- <feature name="jetty" version="12.0.26">
-        <feature version="[6,7)">cxf-specs-jakarta-servlet</feature>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-server/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-session/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-jmx/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-security/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-hpack/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-common/12.0.26</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-server/12.0.26</bundle>
-    </feature> -->
 
     <feature name="cxf-specs" version="${upstream.version}">
         <bundle start-level="9">mvn:org.apache.geronimo.specs/geronimo-osgi-registry/1.1</bundle>
@@ -372,10 +358,11 @@
     </feature>
     <feature name="cxf-tracing-opentelemetry" version="${upstream.version}">
         <feature version="${cxf.tesb.version-range}">cxf-core</feature>
-        <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-api/${cxf.opentelemetry.version}</bundle>
-        <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-context/${cxf.opentelemetry.version}</bundle>
-        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv/${cxf.opentelemetry.semconv.version}</bundle>
-        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv-incubating/${cxf.opentelemetry.semconv.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-api/${cxf.opentelemetry.version}$Bundle-Name=Wrap%20of%20Opentelemetry%20Api&amp;Bundle-SymbolicName=wrap_io.opentelemetry.opentelemetry-api&amp;Bundle-Version=${cxf.opentelemetry.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-common/${cxf.opentelemetry.version}$Bundle-Name=Wrap%20of%20Opentelemetry%20Common&amp;Bundle-SymbolicName=wrap_io.opentelemetry.opentelemetry-common&amp;Bundle-Version=${cxf.opentelemetry.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry/opentelemetry-context/${cxf.opentelemetry.version}$Bundle-Name=Wrap%20of%20Opentelemetry%20Context&amp;Bundle-SymbolicName=wrap_io.opentelemetry.opentelemetry-context&amp;Bundle-Version=${cxf.opentelemetry.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv/${cxf.opentelemetry.semconv.version}$Bundle-Name=Wrap%20of%20Opentelemetry%20Semconv&amp;Bundle-SymbolicName=wrap_io.opentelemetry.opentelemetry-semconv&amp;Bundle-Version=${cxf.opentelemetry.semconv.version}</bundle>
+        <bundle start-level="35">wrap:mvn:io.opentelemetry.semconv/opentelemetry-semconv-incubating/${cxf.opentelemetry.semconv.version}$Bundle-Name=Wrap%20of%20Opentelemetry%20Semconv%20Incubating&amp;Bundle-SymbolicName=wrap_io.opentelemetry.opentelemetry-semconv-incubating&amp;Bundle-Version=${cxf.opentelemetry.semconv.version}</bundle>
         <bundle start-level="40">mvn:org.apache.cxf/cxf-integration-tracing-opentelemetry/${upstream.version}</bundle>
     </feature>
     <!-- <feature name="cxf-rs-description-swagger2" version="${upstream.version}">

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -88,14 +88,14 @@
 
         <!-- please maintain alphabetical order here -->
         <cxf.activemq.artemis.version>2.53.0</cxf.activemq.artemis.version>
-        <cxf.ahc.version>3.0.1</cxf.ahc.version>
+        <cxf.ahc.version>3.0.10</cxf.ahc.version>
         <cxf.arquillian.version>1.8.0.Final</cxf.arquillian.version>
         <cxf.arquillian.weld.container.version>3.0.2.Final</cxf.arquillian.weld.container.version>
         <cxf.aspectj.version>1.9.22.1</cxf.aspectj.version>
         <cxf.assertj.version>3.26.3</cxf.assertj.version>
         <cxf.atmosphere.version.range>[3.0, 4.0)</cxf.atmosphere.version.range>
         <cxf.atmosphere.version>3.0.13</cxf.atmosphere.version>
-        <cxf.bcprov.version>1.81</cxf.bcprov.version>
+        <cxf.bcprov.version>1.84</cxf.bcprov.version>
         <cxf.brave.version>6.0.3</cxf.brave.version>
         <cxf.cdi.api.version>4.1.0</cxf.cdi.api.version>
         <cxf.classgraph.version>4.8.25</cxf.classgraph.version>
@@ -184,16 +184,16 @@
         <cxf.microprofile.config.version>3.1</cxf.microprofile.config.version>
         <cxf.microprofile.rest.client.version>3.0.1</cxf.microprofile.rest.client.version>
         <cxf.microprofile.openapi.version>3.1.2</cxf.microprofile.openapi.version>
-        <cxf.mina.version>2.2.4</cxf.mina.version>
+        <cxf.mina.version>2.2.7</cxf.mina.version>
         <cxf.mockito.version>5.14.2</cxf.mockito.version>
         <cxf.msv.version>2022.7</cxf.msv.version>
-        <cxf.neethi.version>3.2.1</cxf.neethi.version>
+        <cxf.neethi.version>3.2.2</cxf.neethi.version>
         <cxf.netty.version.range>[4,5)</cxf.netty.version.range>
-        <cxf.netty.version>4.1.132.Final</cxf.netty.version>
+        <cxf.netty.version>4.1.133.Final</cxf.netty.version>
         <cxf.netty.tcnative.version>2.0.69.Final</cxf.netty.tcnative.version>
         <cxf.olingo.version>2.0.12</cxf.olingo.version>
         <cxf.openjpa.version>3.2.2</cxf.openjpa.version>
-        <cxf.opentelemetry.version>1.45.0</cxf.opentelemetry.version>
+        <cxf.opentelemetry.version>1.62.0</cxf.opentelemetry.version>
         <cxf.opentelemetry.semconv.version>1.28.0-alpha</cxf.opentelemetry.semconv.version>
         <cxf.opentracing.version>0.33.0</cxf.opentracing.version>
         <cxf.openwebbeans.version>2.0.27</cxf.openwebbeans.version>
@@ -217,8 +217,8 @@
         <cxf.spring.boot.version>3.4.0</cxf.spring.boot.version>
         <cxf.spring.ldap.version>3.2.11</cxf.spring.ldap.version>
         <cxf.spring.mock>spring-test</cxf.spring.mock>
-        <cxf.spring.security.version>6.4.7</cxf.spring.security.version>
-        <cxf.spring.version>6.2.11</cxf.spring.version>
+        <cxf.spring.security.version>6.5.10</cxf.spring.security.version>
+        <cxf.spring.version>6.2.18</cxf.spring.version>
         <cxf.stax-ex.version>1.8.3</cxf.stax-ex.version>
         <cxf.swagger.ui.version>5.18.2</cxf.swagger.ui.version>
         <cxf.swagger.v3.version>2.2.26</cxf.swagger.v3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,14 +40,14 @@
     </issueManagement>
     <properties>
         <original.version>4.1.0.2</original.version>
-        <cxf.features.tesb.version>4.1.0.2.20260323</cxf.features.tesb.version>
+        <cxf.features.tesb.version>4.1.0.2.20260512</cxf.features.tesb.version>
         <cxf.tesb.version-range>[4.1,4.2)</cxf.tesb.version-range>
         <cxf.tesb.major-version-range>[4,5)</cxf.tesb.major-version-range>
         <cxf.rs.openapi.v3.tesb.version>4.1.0.2.20251023</cxf.rs.openapi.v3.tesb.version>
         <cxf.rs.swagger.ui.tesb.version>4.1.0.2.20251023</cxf.rs.swagger.ui.tesb.version>
 
-        <cxf.async-http-client.tesb.version>2.12.4</cxf.async-http-client.tesb.version>
-        <cxf.bcprov.tesb.version>1.81</cxf.bcprov.tesb.version>
+        <cxf.async-http-client.tesb.version>2.15.0</cxf.async-http-client.tesb.version>
+        <cxf.bcprov.tesb.version>1.84</cxf.bcprov.tesb.version>
         <cxf.dtd.parser.tesb.version>1.4.5</cxf.dtd.parser.tesb.version>
         <cxf.classgraph.tesb.version>4.8.175</cxf.classgraph.tesb.version>
         <cxf.fastinfoset.tesb.version>2.0.0</cxf.fastinfoset.tesb.version>
@@ -61,7 +61,7 @@
         <cxf.camel.tesb.version>4.8.1</cxf.camel.tesb.version>
         <cxf.camel.cxf.tesb.version>4.8.1.20250901</cxf.camel.cxf.tesb.version>
         <cxf.camel.features.tesb.version>4.8.1.20250901</cxf.camel.features.tesb.version>
-        <cxf.mina.tesb.version>2.2.4</cxf.mina.tesb.version>
+        <cxf.mina.tesb.version>2.2.7</cxf.mina.tesb.version>
         <cxf.opensaml.tesb.version>4.3.2</cxf.opensaml.tesb.version>
         <!-- <cxf.opensaml.tesb.version-range>[4,5)</cxf.opensaml.tesb.version-range> -->
         <cxf.xmlsec.bundle.tesb.version>2.3.4</cxf.xmlsec.bundle.tesb.version>


### PR DESCRIPTION
CVE-2026-40490
-- async-http-client 2.12.4 -> 2.15.0

CVE-2026-3505,
CVE-2026-5588,
CVE-2026-5598,
CVE-2026-0636
-- bouncycastle 1.81 -> 1.84

CVE-2026-41409,
CVE-2026-41635,
CVE-2026-42778,
CVE-2026-42779
-- mina 2.2.4 -> 2.2.7

CVE-2026-42402,
CVE-2026-42403,
CVE-2026-42404
-- neethi 3.2.1 -> 3.2.2

CVE-2026-42583,
CVE-2026-42579,
CVE-2026-42584,
CVE-2026-42587,
CVE-2026-41417,
CVE-2026-42580,
CVE-2026-42581,
CVE-2026-42585
-- netty 4.1.132.Final -> netty 4.1.133.Final

CVE-2026-45292
-- opentelemetry 1.45.0 -> 1.62.0

CVE-2026-22745,
CVE-2026-22741
-- spring 6.2.17 -> 6.2.18

CVE-2026-22746,
CVE-2026-22748
-- spring-security 6.3.10 -> 6.5.10